### PR TITLE
Change back flatcar-metadata to coreos-metadata

### DIFF
--- a/dracut/30ignition/flatcar-digitalocean-network.service
+++ b/dracut/30ignition/flatcar-digitalocean-network.service
@@ -7,4 +7,4 @@ Wants=systemd-networkd.service initrd-root-fs.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/flatcar-metadata --cmdline --network-units=/run/systemd/network/ --hostname=/sysroot/etc/hostname
+ExecStart=/usr/bin/coreos-metadata --cmdline --network-units=/run/systemd/network/ --hostname=/sysroot/etc/hostname

--- a/dracut/30ignition/flatcar-static-network.service
+++ b/dracut/30ignition/flatcar-static-network.service
@@ -10,4 +10,4 @@ Before=ignition-files.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/flatcar-metadata --cmdline --network-units=/sysroot/etc/systemd/network/ --hostname=/sysroot/etc/hostname
+ExecStart=/usr/bin/coreos-metadata --cmdline --network-units=/sysroot/etc/systemd/network/ --hostname=/sysroot/etc/hostname

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -9,7 +9,7 @@ depends() {
 install() {
     inst_multiple \
         ignition \
-        flatcar-metadata \
+        coreos-metadata \
         useradd \
         usermod \
         groupadd \


### PR DESCRIPTION
There's no need to rename this since coreos-metadata is just the name of
the project.