### PR TITLE
dracut: remove systemd-tmpfiles-setup from initramfs

### DIFF
--- a/dracut/99start-root/module-setup.sh
+++ b/dracut/99start-root/module-setup.sh
@@ -4,4 +4,7 @@
 
 install() {
     inst_rules "$moddir/65-start-root.rules"
+
+    rm -f "$initdir/usr/lib/systemd/system/systemd-tmpfiles-setup.service"
+    rm -f "$initdir/usr/lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup.service"
 }


### PR DESCRIPTION
Although no unit depends on `systemd-tmpfiles-setup.service` explicitly, it gets sometimes pulled in automatically for some reasons. As a result, the initramfs has both `systemd-tmpfiles-setup-dev.service` and `systemd-tmpfiles-setup.service`, so units like `systemd-resolved.service` cannot start because of an ordering cycle issue. That's the case especially for ARM64 architecture.

To fix that, let's remove `systemd-tmpfile-setup.service` from the initramfs.