### PR TITLE
Support coreos.first_boot for compatibility

### DIFF
--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -35,7 +35,7 @@ add_requires() {
 # This can't be done with ConditionKernelCommandLine because that always
 # starts the unit's dependencies. We want to start networkd only on first
 # boot.
-if $(cmdline_bool flatcar.first_boot 0); then
+if $(cmdline_bool flatcar.first_boot 0) || $(cmdline_bool coreos.first_boot 0); then
     add_requires ignition-disks.service
     add_requires ignition-files.service
     # Only try to mount the ESP if GRUB detected a first_boot file

--- a/dracut/35torcx/torcx-profile-populate-generator
+++ b/dracut/35torcx/torcx-profile-populate-generator
@@ -35,6 +35,6 @@ add_requires() {
 # This can't be done with ConditionKernelCommandLine because that always
 # starts the unit's dependencies. We want to start networkd only on first
 # boot.
-if $(cmdline_bool flatcar.first_boot 0); then
+if $(cmdline_bool flatcar.first_boot 0) || $(cmdline_bool coreos.first_boot 0); then
     add_requires torcx-profile-populate.service
 fi

--- a/dracut/99start-root/65-start-root.rules
+++ b/dracut/99start-root/65-start-root.rules
@@ -19,11 +19,16 @@ SUBSYSTEM!="block", GOTO="start_root_end"
 # Ignition may want to clobber partitions used in a raid array, so
 # skip assembling them when Ignition is going to run.
 IMPORT{cmdline}="flatcar.first_boot"
+IMPORT{cmdline}="coreos.first_boot"
 # Possible values for not running Ignition from 30ignition/ignition-generator
 ENV{flatcar.first_boot}=="", GOTO="start_root"
 ENV{flatcar.first_boot}=="0", GOTO="start_root"
 ENV{flatcar.first_boot}=="no", GOTO="start_root"
 ENV{flatcar.first_boot}=="off", GOTO="start_root"
+ENV{coreos.first_boot}=="", GOTO="start_root"
+ENV{coreos.first_boot}=="0", GOTO="start_root"
+ENV{coreos.first_boot}=="no", GOTO="start_root"
+ENV{coreos.first_boot}=="off", GOTO="start_root"
 GOTO="start_root_end"
 
 LABEL="start_root"


### PR DESCRIPTION
In addition to https://github.com/flatcar-linux/bootengine/pull/7 it adds support for the `first_boot` variable. In the case of GRUB it is not needed because we assume that only the image building writes the file and uses the `flatcar` path.

Edit: Added support in the udev rule, too.