### PR TITLE
Revert "digitalocean: Match for all interfaces"

### DIFF
--- a/dracut/03flatcar-network/yy-digitalocean-coreos.network
+++ b/dracut/03flatcar-network/yy-digitalocean-coreos.network
@@ -1,6 +1,6 @@
 [Match]
 KernelCommandLine=coreos.oem.id=digitalocean
-Name=e*
+Name=eth0
 
 [Network]
 DHCP=yes

--- a/dracut/03flatcar-network/yy-digitalocean.network
+++ b/dracut/03flatcar-network/yy-digitalocean.network
@@ -1,6 +1,6 @@
 [Match]
 KernelCommandLine=flatcar.oem.id=digitalocean
-Name=e*
+Name=eth0
 
 [Network]
 DHCP=yes


### PR DESCRIPTION
This reverts commit 88119e96e0aa5784d20d3f89836422af75adf57d.

On DigitalOcean eth0 is still used, so we can just continue
to match for it. Maybe 'e*0' would be possible, too.
There is a problem when IPv6 is activated currently, thus,
just revert the patch.

Note: Pick for alpha and edge.