### PR TITLE
ignition: Remove /boot/coreos/first_boot

### DIFF
--- a/dracut/30ignition/ignition-quench.service
+++ b/dracut/30ignition/ignition-quench.service
@@ -16,4 +16,4 @@ After=sysroot-boot.service
 Type=oneshot
 # We will only run if GRUB detected this file. Fail if we are unable to
 # remove it, rather than risking rerunning Ignition at next boot.
-ExecStart=/bin/rm /sysroot/boot/flatcar/first_boot
+ExecStart=/bin/sh -c 'if [ ! -e /sysroot/boot/flatcar/first_boot ] && [ ! -e /sysroot/boot/coreos/first_boot ]; then echo "error: /sysroot/boot/(flatcar|coreos)/first_boot not found"; exit 1; else  [ -e /sysroot/boot/flatcar/first_boot ] && rm /sysroot/boot/flatcar/first_boot; [ -e /sysroot/boot/coreos/first_boot ] && rm /sysroot/boot/coreos/first_boot; fi'


### PR DESCRIPTION
Whether /boot/coreos/first_boot or /boot/flatcar/first_boot
is used depends on the GRUB code present in the MBR/EFI.
Remove both files in the initramfs depending on whether
they exist and error out if deletion fails or if none of
them existed.

Note: Create a PR for coreos-overlay after merging (and also pick that for Alpha and Edge when merged).