### PR TITLE
Simplify ignition-quench service and ensure 0 exit code

### DIFF
--- a/dracut/30ignition/ignition-quench.service
+++ b/dracut/30ignition/ignition-quench.service
@@ -16,4 +16,4 @@ After=sysroot-boot.service
 Type=oneshot
 # We will only run if GRUB detected this file. Fail if we are unable to
 # remove it, rather than risking rerunning Ignition at next boot.
-ExecStart=/bin/sh -c 'if [ ! -e /sysroot/boot/flatcar/first_boot ] && [ ! -e /sysroot/boot/coreos/first_boot ]; then echo "error: /sysroot/boot/(flatcar|coreos)/first_boot not found"; exit 1; else  [ -e /sysroot/boot/flatcar/first_boot ] && rm /sysroot/boot/flatcar/first_boot; [ -e /sysroot/boot/coreos/first_boot ] && rm /sysroot/boot/coreos/first_boot; fi'
+ExecStart=/bin/sh -c 'if [ ! -e /sysroot/boot/flatcar/first_boot ] && [ ! -e /sysroot/boot/coreos/first_boot ]; then echo "error: /sysroot/boot/(flatcar|coreos)/first_boot not found"; exit 1; else rm -f /sysroot/boot/flatcar/first_boot /sysroot/boot/coreos/first_boot; fi'


### PR DESCRIPTION
The shell script propagated the error code of the [ -e coreos ]
check as exit code for the whole program because it is the last
statement that is executed.
Use the --force argument for rm and try to delete both files.
This gives a 0 exit code if the files got deleted (or never existed
but that is covered in the if condition before) but still returns
an error if the files could not be deleted.
