### PR TITLE
Order sysroot-boot.service to stop before switching root starts

### DIFF
--- a/dracut/30ignition/sysroot-boot.service
+++ b/dracut/30ignition/sysroot-boot.service
@@ -11,6 +11,10 @@ RequiresMountsFor=/sysroot
 Requires=initrd-setup-root.service
 After=initrd-setup-root.service
 
+# This is to make sure that /sysroot/boot is unmounted before we start
+# switching root in initrd-switch-root.target.
+Before=initrd-switch-root.target
+
 Conflicts=dracut-emergency.service emergency.service emergency.target
 Conflicts=initrd-switch-root.target umount.target
 


### PR DESCRIPTION
This commit makes sure that the `sysroot-boot.service` is fully stopped before the conflicting `initrd-switch-root.target` is started. This is to address https://github.com/flatcar-linux/Flatcar/issues/83.

# How to use

Build flatcar image with this change (there is a [krnowak/bootengine-fix-edge coreos-overlay branch](https://github.com/flatcar-linux/coreos-overlay/tree/krnowak/bootengine-fix-edge)) and run it repeatedly on azure, like https://github.com/flatcar-linux/Flatcar/issues/83 describes.

# Testing done

I've run this test 5 times so far and the journal output always contained sysroot-boot being completely stopped successfully and always before starting the switching root target.

```
May 16 13:28:14.502000 audit[1]: SERVICE_STOP pid=1 uid=0 auid=4294967295 ses=4294967295 subj=kernel msg='unit=sysroot-boot comm="systemd" exe="/usr/lib64/systemd/systemd" hostname=? addr=? terminal=? res=success'
May 16 13:28:14.499845 systemd[1]: Stopped /sysroot/boot.
[…]
May 16 13:28:14.767841 systemd[1]: Reached target Switch Root.
May 16 13:28:14.769666 systemd[1]: Starting Switch Root...
May 16 13:28:14.782608 systemd[1]: Switching root.
```