### PR TITLE
Support the CoreOS GRUB /boot/coreos/first_boot flag file

### DIFF
--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -39,7 +39,7 @@ if $(cmdline_bool flatcar.first_boot 0) || $(cmdline_bool coreos.first_boot 0); 
     add_requires ignition-disks.service
     add_requires ignition-files.service
     # Only try to mount the ESP if GRUB detected a first_boot file
-    if [[ $(cmdline_arg flatcar.first_boot) = "detected" ]]; then
+    if [[ $(cmdline_arg flatcar.first_boot) = "detected" ]] || [[ $(cmdline_arg coreos.first_boot) = "detected" ]]; then
         add_requires ignition-quench.service
     fi
     if [[ $(cmdline_arg flatcar.oem.id) == "packet" ]] || [[ $(cmdline_arg coreos.oem.id) == "packet" ]]; then


### PR DESCRIPTION
When a machine is migrated from CoreOS, GRUB code is not migrated and
specifies the coreos.first_boot=detected kernel parameter if the flag file
/boot/coreos/first_boot exists.
Run Ignition if the kernel parameter is present.


# How to use

See https://github.com/flatcar-linux/scripts/pull/68

# Testing done

See https://github.com/flatcar-linux/scripts/pull/68