### PR TITLE
dracut: Ensure that /etc/systemd/network/ exists to write networkd unit

### DIFF
--- a/dracut/03flatcar-network/parse-ip-for-networkd.sh
+++ b/dracut/03flatcar-network/parse-ip-for-networkd.sh
@@ -71,6 +71,7 @@ for p in $(getargs ip=); do
     # Enough validation, write the network file
     # Count down so that early ip= arguments are overridden by later ones
     _net_file=/etc/systemd/network/10-dracut-cmdline-$(( 99 - _net_count++ )).network
+    mkdir -p /etc/systemd/network
     echo '[Match]' > $_net_file
     [ -n "$dev" ] && echo "Name=$dev" >> $_net_file
     echo '[Link]' >> $_net_file


### PR DESCRIPTION
The /etc/systemd/network/ folder didn't exist by default, which caused
static IP assignment via the kernel command line being broken
(The format `ip=<ip>::<gateway>:<netmask>:<hostname>:<iface>:none[:<dns1>[:<dns2>]]`
is documented in https://docs.flatcar-linux.org/ignition/network-configuration/#using-static-ip-addresses-with-ignition
and parsed in the initramfs).
Create the folder before trying to write a networkd unit into it.

Reported in https://github.com/flatcar-linux/Flatcar/issues/148


# How to use

Boot a QEMU VM and add this kernel parameter in GRUB:
```
ip=10.0.2.15::10.0.2.2:255.255.255.0::eth0:none:1.1.1.1:8.8.8.8
```

Currently `journalctl --e -u dracut-cmdline` show these errors which should be gone with the patch:
```
dracut-cmdline[191]: //lib/dracut/hooks/cmdline/99-parse-ip-for-networkd.sh: line 76: /etc/systemd/network/10-dracut-cmdline-99.network: No such file or directory
```

# Testing done

The error messages are gone following the instructions above. I didn't test it with something else.