### PR TITLE
Add a Match section for systemd  to not ignore .network files

### DIFF
--- a/dracut/03flatcar-network/parse-ip-for-networkd.sh
+++ b/dracut/03flatcar-network/parse-ip-for-networkd.sh
@@ -73,7 +73,7 @@ for p in $(getargs ip=); do
     _net_file=/etc/systemd/network/10-dracut-cmdline-$(( 99 - _net_count++ )).network
     mkdir -p /etc/systemd/network
     echo '[Match]' > $_net_file
-    [ -n "$dev" ] && echo "Name=$dev" >> $_net_file
+    _dev=${dev:-"*"}; echo "Name=$_dev" >> $_net_file
     echo '[Link]' >> $_net_file
     [ -n "$macaddr" ] && echo "MACAddress=$macaddr" >> $_net_file
     [ -n "$mtu" ] && echo "MTUBytes=$mtu" >> $_net_file

--- a/dracut/03flatcar-network/yy-pxe.network
+++ b/dracut/03flatcar-network/yy-pxe.network
@@ -1,4 +1,5 @@
 [Match]
+Name=*
 KernelCommandLine=!root
 
 [Network]

--- a/dracut/03flatcar-network/zz-default.network
+++ b/dracut/03flatcar-network/zz-default.network
@@ -1,3 +1,6 @@
+[Match]
+Name=*
+
 [Network]
 DHCP=yes
 


### PR DESCRIPTION
# Add a Match section for systemd to not ignore

systemd 245 ignores .link and .network files if the Match  section is empty. More details in the [NEWS](https://github.com/systemd/systemd/blob/master/NEWS#L830-L833) entry. 

This should be merged with https://github.com/flatcar-linux/coreos-overlay/pull/448

Signed-off-by: Sayan Chowdhury <sayan.chowdhury2012@gmail.com>

# How to use

```bash
emerge-amd54-usr sys-kernel/bootengine
```


# Testing done

Without these options, the SSH to the machine was broken, and no packets were received by the machine. This fixes the issue. 
