### PR TITLE
setup-root: Put the user/group databases early in rootfs setup

### DIFF
--- a/dracut/99setup-root/initrd-setup-root
+++ b/dracut/99setup-root/initrd-setup-root
@@ -6,6 +6,12 @@
 COREOS_BLANK_MACHINE_ID="42000000000000000000000000000042"
 MACHINE_ID_FILE="/sysroot/etc/machine-id"
 
+# This creates the modifiable users/groups in /sysroot/etc,
+# initializing the shadow database in the process. This needs to
+# happen early, so systemd-tmpfiles can read the user info from
+# /sysroot.
+/usr/sbin/flatcar-tmpfiles /sysroot
+
 # Initialize base filesystem
 systemd-tmpfiles --root=/sysroot --create \
     baselayout.conf baselayout-etc.conf baselayout-usr.conf \
@@ -18,10 +24,6 @@ for config in baselayout-ldso.conf selinux-base.conf libsemanage.conf; do
         systemd-tmpfiles --root=/sysroot --create "${config}"
     fi
 done
-
-# This creates the modifiable users/groups in /sysroot/etc,
-# initializing the shadow database in the process.
-/usr/sbin/flatcar-tmpfiles /sysroot
 
 # Remove our phony id. systemd will initialize this during boot.
 if grep -qs "${COREOS_BLANK_MACHINE_ID}" "${MACHINE_ID_FILE}"; then


### PR DESCRIPTION
This PR is a part of the systemd update.

systemd-tmpfiles in systemd v246 requires the user and group databases
in the custom root if it's invoked with --root flag. This change
prepares for it.

Test build is here: http://localhost:9091/job/os/job/manifest/1138/