### PR TITLE
Set hostname for EC2 and OpenStack from metadata

### DIFF
--- a/dracut/30ignition/flatcar-metadata-hostname.service
+++ b/dracut/30ignition/flatcar-metadata-hostname.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Flatcar Metadata Hostname Agent
+DefaultDependencies=false
+Before=initrd.target
+After=systemd-networkd.service initrd-root-fs.target
+Wants=systemd-networkd.service initrd-root-fs.target
+
+# Ensure Ignition can overwrite /etc/hostname
+Before=ignition-files.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/coreos-metadata --cmdline --hostname=/sysroot/etc/hostname

--- a/dracut/30ignition/flatcar-openstack-hostname.service
+++ b/dracut/30ignition/flatcar-openstack-hostname.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Flatcar OpenStack Metadata Hostname Agent
+DefaultDependencies=false
+Before=initrd.target
+After=systemd-networkd.service initrd-root-fs.target
+Wants=systemd-networkd.service initrd-root-fs.target
+
+# Ensure Ignition can overwrite /etc/hostname
+Before=ignition-files.service
+
+[Service]
+Type=oneshot
+# Special case: the oem_id openstack does not match the afterburn name openstack-metadata
+ExecStart=/usr/bin/coreos-metadata --provider openstack-metadata --hostname=/sysroot/etc/hostname

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -57,6 +57,12 @@ Conflicts=emergency.service
 Conflicts=dracut-emergency.service
 EOF
     fi
+    if [[ $(cmdline_arg flatcar.oem.id) == "ec2" ]] || [[ $(cmdline_arg coreos.oem.id) == "ec2" ]]; then
+        add_requires flatcar-metadata-hostname.service
+    fi
+    if [[ $(cmdline_arg flatcar.oem.id) == "openstack" ]] || [[ $(cmdline_arg coreos.oem.id) == "openstack" ]]; then
+        add_requires flatcar-openstack-hostname.service
+    fi
 fi
 
 # Write ignition-setup.service customized for PXE/ISO or regular boot

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -52,6 +52,12 @@ install() {
     inst_simple "$moddir/flatcar-static-network.service" \
         "$systemdsystemunitdir/flatcar-static-network.service"
 
+    inst_simple "$moddir/flatcar-metadata-hostname.service" \
+        "$systemdsystemunitdir/flatcar-metadata-hostname.service"
+
+    inst_simple "$moddir/flatcar-openstack-hostname.service" \
+        "$systemdsystemunitdir/flatcar-openstack-hostname.service"
+
     inst_rules \
         60-cdrom_id.rules \
         66-azure-storage.rules \


### PR DESCRIPTION
Similar to what is done for DigitalOcean and Packet, we can set the
hostname for EC2 and OpenStack through afterburn.
For OpenStack the name in afterburn does not match the oem_id set on
    the kernel commandline from GRUB, and a special service is added
    which sets the provider directly.

# How to use

Run kola tests and grep for `hostname` in the console/journal output.

AWS:
Compared to the current state the end result is the same because `systemd-hostnamed` sets the final hostname.
However, before that happens the hostname is currently not set while with the change here the hostname is already set as soon as the system starts.

OpenStack:
not tested

# Testing done

[AWS here](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2055/cldsv/)