### PR TITLE
Enable iSCSI netroot devices on Flatcar

### DIFF
--- a/dracut/03flatcar-network/10-down.conf
+++ b/dracut/03flatcar-network/10-down.conf
@@ -1,3 +1,0 @@
-[Service]
-ExecStop=/usr/bin/ip addr flush up
-ExecStop=/usr/bin/ip link set group default down

--- a/dracut/03flatcar-network/module-setup.sh
+++ b/dracut/03flatcar-network/module-setup.sh
@@ -15,8 +15,8 @@ install() {
         $systemdsystemunitdir/systemd-resolved.service \
         /etc/systemd/resolved.conf
 
-    inst_simple "$moddir/10-down.conf" \
-        "$systemdsystemunitdir/systemd-networkd.service.d/10-down.conf"
+    inst_simple "$moddir/network-cleanup.service" \
+        "$systemdsystemunitdir/network-cleanup.service"
 
     inst_simple "$moddir/10-nodeps.conf" \
         "$systemdsystemunitdir/systemd-resolved.service.d/10-nodeps.conf"
@@ -26,6 +26,9 @@ install() {
 
     inst_simple "$moddir/yy-digitalocean.network" \
         "$systemdutildir/network/yy-digitalocean.network"
+
+    inst_simple "$moddir/yy-netroot.network" \
+        "$systemdutildir/network/yy-netroot.network"
 
     inst_simple "$moddir/yy-pxe.network" \
         "$systemdutildir/network/yy-pxe.network"
@@ -51,4 +54,6 @@ install() {
     # we only want it when pulled in
     systemctl --root "$initdir" disable systemd-networkd.service
     systemctl --root "$initdir" disable systemd-networkd.socket
+
+    systemctl --root "$initdir" enable network-cleanup.service
 }

--- a/dracut/03flatcar-network/network-cleanup.service
+++ b/dracut/03flatcar-network/network-cleanup.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Network Cleanup
+DefaultDependencies=false
+RefuseManualStart=true
+RefuseManualStop=true
+# If we're using a netroot, we can't tear down the network
+ConditionKernelCommandLine=!netroot
+
+PartOf=systemd-networkd.service
+Before=systemd-networkd.service
+
+[Service]
+RemainAfterExit=true
+ExecStop=/usr/bin/ip addr flush up
+ExecStop=/usr/bin/ip link set group default down
+
+[Install]
+WantedBy=systemd-networkd.service

--- a/dracut/03flatcar-network/yy-netroot.network
+++ b/dracut/03flatcar-network/yy-netroot.network
@@ -1,0 +1,11 @@
+[Match]
+KernelCommandLine=netroot
+
+[Network]
+DHCP=yes
+# Root is on the network, it can't go down at switch-root
+KeepConfiguration=yes
+
+[DHCP]
+UseMTU=true
+UseDomains=true

--- a/update-bootengine
+++ b/update-bootengine
@@ -33,6 +33,7 @@ DRACUT_ARGS=(
     --omit lvm
     --omit multipath
     --omit network
+    -a iscsi
     )
 
 SETUP_MOUNTS=


### PR DESCRIPTION
# Enable iSCSI netroot devices on Flatcar

This change enables the iSCSI module on dracut and changes the network behavior when Flatcar boots, to avoid bringing down the network when doing the switch-root operation.

This change is based on the CoreOS support for Oracle OCI bare metal machines, that was removed in 2018 with  https://github.com/kinvolk/bootengine/commit/deba0732daec569545cf456f0cc514f17c7529b5.

# Testing done

I've run CI with this change and it passed. I've also used the created image to mount a successfully mount an iSCSI netroot device and boot into the corresponding Flatcar instance.