### PR TITLE
network: don't manage the loopback interface

### DIFF
--- a/dracut/03flatcar-network/zz-default.network
+++ b/dracut/03flatcar-network/zz-default.network
@@ -1,5 +1,6 @@
 [Match]
 Name=*
+Type=!loopback
 
 [Network]
 DHCP=yes


### PR DESCRIPTION
The default network configuration is DHCP and was also applied to the
loopback interface. This resulted in the loopback interface being in a
"managed" state in networkd and sometimes caused the IP address to be
deconfigured, resulting in errors when something tries to make use of
the loopback interface, like resolved
(see https://flaviutamas.com/2019/fixing-name-resolution-after-sleep).
Exclude the loopback interface from the default configuration to make
it "unmanaged".

Also see https://github.com/kinvolk/init/pull/40

## How to use

See if `systemd-resolved[55175]: Failed to listen on UDP socket 127.0.0.53:53: Cannot assign requested address` messages are gone in the case of endless loops in the initramfs (e.g., due to a non-reachable ignition URL), and if nothing else breaks because of the change

## Testing done

[for all platforms](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2618/cldsv/)