### PR TITLE
dracut: fall back to expected dm-verity hash offset

### DIFF
--- a/dracut/10usr-generator/usr-generator
+++ b/dracut/10usr-generator/usr-generator
@@ -35,6 +35,9 @@ cmdline_arg() {
 usr=$(cmdline_arg usr)
 usrfstype=$(cmdline_arg usrfstype auto)
 usrflags=$(cmdline_arg usrflags ro)
+if [[ "$(echo "${usrflags}" | grep -E '(^ro$|^ro,|,ro$|,ro,)')" != "" ]]; then
+  usrflags="${usrflags},norecovery"
+fi
 
 case "${usr}" in
     LABEL=*)
@@ -58,7 +61,23 @@ esac
 
 # Only proceed if the source is a path.
 if [[ "${usr}" != /* ]]; then
+  if [[ -z "${usr}" && -f /usr.squashfs ]]; then
+    # Don't set "norecovery" for squashfs
     exit 0
+  fi
+  # Add "norecovery" to systemd-fstab-generator's unit and exit
+  mount_usrflags=$(cmdline_arg mount.usrflags ro)
+  if [[ "$(echo "${mount_usrflags}" | grep -E '(^ro$|^ro,|,ro$|,ro,)')" != "" ]]; then
+    # Don't set "norecovery" when mounting rw
+    exit 0
+  fi
+  mount_usrflags="${mount_usrflags},norecovery"
+  mkdir -p "${UNIT_DIR}/sysroot-usr.mount.d"
+  cat >"${UNIT_DIR}/sysroot-usr.mount.d/10-norecovery.conf" <<EOF
+[Mount]
+Options=${mount_usrflags}
+EOF
+  exit 0
 fi
 
 cat >"${UNIT_DIR}/sysroot-usr.mount" <<EOF

--- a/dracut/10verity-generator/verity-generator
+++ b/dracut/10verity-generator/verity-generator
@@ -74,7 +74,8 @@ if [[ -n "${usr}" && -n "${usrhash}" ]]; then
 	[Service]
 	Type=oneshot
 	RemainAfterExit=yes
-	ExecStart=/bin/sh -c '/sbin/veritysetup create usr --hash-offset="\$(e2size ${usr})" "${usr}" "${usr}" "${usrhash}"'
+	# Try to query the filesystem size dynamically but otherwise fall back to the expected value from the image GPT layout
+	ExecStart=/bin/sh -c '/sbin/veritysetup create usr --hash-offset="\$(e2size ${usr} || echo 1065345024)" "${usr}" "${usr}" "${usrhash}"'
 	# If there's a hash mismatch during table initialization,
 	# veritysetup reports it on stderr but still exits 0, and
 	# dev-mapper-usr.device ends up waiting indefinitely. Manually


### PR DESCRIPTION
- dracut: fall back to expected dm-verity hash offset
    
    The hash offset is found by looking at the filesystem size. When
    e2size can't find the size it returns "Success" in stderr for whatever
    reason and fortunately still returns an error exit code, stdout stays
    empty. This means that the dm-verity device setup won't work because
    the hash offset is the empty string. However, the hash offset is
    actually fixed because the GPT disk layout has to stay the same in
    Flatcar Container Linux as the partition contents are swapped out
    when updating. In case another filesystem like btrfs is used, e2size
    doesn't work and it makes sense to fall back to the only value which
    is supported in general.
    Hard code the hash offset value coming from the /usr filesystem size
    defined in flatcar-scripts/build_library/disk_layout.json.
- dracut: add norecovery mount option for /usr
    
    The /usr partition should not be modified during mounting, even if it
    has some corruption. Rewriting the filesystem log would cause dm-verity
    errors when dm-verity is enabled later again. While the /usr partition
    normally is on a dm-verity block device in read-only mode there is some
    option to mount the partition without dm-verity and it wouldn't be a
    read-only block device anymore.
    Add the norecovery mount option which is supported for ext4 and btrfs.

## How to use/testing done

This was built and tested with the coreos-overlay branch `kai/bootengine-verity-hashoffset` from https://github.com/kinvolk/coreos-overlay/pull/1106 and flatcar-scripts branch `kai/btrfs-usr-oem` from https://github.com/kinvolk/flatcar-scripts/pull/131 in http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3029/cldsv/ where the Flatcar image that has a btrfs /usr partition and OEM partition.
While the actual switch to a btrfs filesystem on the /usr partition is only possible when all changes are part of a Stable release because update-engine needs to know how to handle the new filesystem when updating, we can already do the switch for the OEM partition.