### PR TITLE
dracut: issue a kernel panic on dm-verity corruption

### DIFF
--- a/dracut/10verity-generator/verity-generator
+++ b/dracut/10verity-generator/verity-generator
@@ -75,7 +75,7 @@ if [[ -n "${usr}" && -n "${usrhash}" ]]; then
 	Type=oneshot
 	RemainAfterExit=yes
 	# Try to query the filesystem size dynamically but otherwise fall back to the expected value from the image GPT layout
-	ExecStart=/bin/sh -c '/sbin/veritysetup create usr --hash-offset="\$(e2size ${usr} || echo 1065345024)" "${usr}" "${usr}" "${usrhash}"'
+	ExecStart=/bin/sh -c '/sbin/veritysetup create usr --panic-on-corruption --hash-offset="\$(e2size ${usr} || echo 1065345024)" "${usr}" "${usr}" "${usrhash}"'
 	# If there's a hash mismatch during table initialization,
 	# veritysetup reports it on stderr but still exits 0, and
 	# dev-mapper-usr.device ends up waiting indefinitely. Manually


### PR DESCRIPTION
In the default mode dm-verity leads to failed read syscalls when
corruption is detected. This is hard to spot and also not secure
because it allows altering system behavior by introducing failures
to particular parts of the system and thus turning off security
mechanisms. Thus, the value of dm-verity isn't really utilized.

Issue a kernel panic instead of just failing a read syscall when
corruption is detected. This allows users to spot the issue and
take action and fully utilizes the advantages of having dm-verity.

## How to use

Together with https://github.com/kinvolk/portage-stable/pull/190 because at least cryptsetup version 2.3.4 is needed

## Testing done

Tested in http://localhost:9091/job/os/job/manifest/3151/cldsv/ but few kola tests need to be changed, done in https://github.com/kinvolk/mantle/pull/197
