### PR TITLE
dracut: let network-cleanup.service finish before entering the rootfs

### DIFF
--- a/dracut/03flatcar-network/network-cleanup.service
+++ b/dracut/03flatcar-network/network-cleanup.service
@@ -7,7 +7,9 @@ RefuseManualStop=true
 ConditionKernelCommandLine=!netroot
 
 PartOf=systemd-networkd.service
-Before=systemd-networkd.service
+Before=systemd-networkd.service initrd-switch-root.target
+# Switching the root filesystem terminates all running services with binaries from the initramfs, we need to finish before that happens
+Conflicts=initrd-switch-root.target
 
 [Service]
 RemainAfterExit=true


### PR DESCRIPTION
The network-cleanup.service failed when it wasn't fast enough to
complete before the root filesystem is switched:
  network-cleanup.service: Current command vanished from the unit file,
  execution of the command list won't be resumed.
Similar to the sysroot-boot.service we need to be finished with the
network-cleanup.service before the switch is done.

Add the ordering and conflicts directives as done in
sysroot-boot.service.


## How to use


## Testing done

Done in http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3185/cldsv/ - looks good, in the past I had seen the errors on Azure kola tests some times but of course with plain testing there is no way to know with races whether they are gone