### PR TITLE
dracut: run emergency.target on ignition/torcx service unit failure

### DIFF
--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -16,6 +16,9 @@ After=systemd-networkd.service
 Wants=systemd-resolved.service
 After=systemd-resolved.service
 
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
 [Service]
 Type=oneshot
 EnvironmentFile=/run/ignition.env

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -21,6 +21,9 @@ After=systemd-networkd.service
 Wants=systemd-resolved.service
 After=systemd-resolved.service
 
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
 [Service]
 Type=oneshot
 EnvironmentFile=/run/ignition.env

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -96,6 +96,9 @@ Before=local-fs-pre.target
 ${nopxe:+Requires=dev-disk-by\x2dlabel-OEM.device
 After=dev-disk-by\x2dlabel-OEM.device}
 
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
 [Service]
 Type=oneshot
 ExecStart=/usr/sbin/ignition-setup ${nopxe:+normal} ${pxe:+pxe}

--- a/dracut/35torcx/torcx-profile-populate.service
+++ b/dracut/35torcx/torcx-profile-populate.service
@@ -22,6 +22,9 @@ After=systemd-resolved.service
 # Runs before initramfs provisioning is completed.
 Before=ignition-quench.service initrd-parse-etc.service
 
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
 [Install]
 RequiredBy=ignition-quench.service
 


### PR DESCRIPTION
# dracut: run emergency.target on ignition/torcx service unit failure

This PR isolates emergency.target when ignition units fail, ensuring that we don't end up with a boot loop in initramfs.

## How to use

```
emerge-amd64-usr bootengine coreos-kernel
```

## Testing done

Tested with invalid ignition configs from https://github.com/kinvolk/Flatcar/issues/434 and https://github.com/kinvolk/Flatcar/issues/468. In both cases the boot now stops and the user sees the ignition error on the console.