### PR TITLE
dracut/ignition: add `wipefs` to the initramfs

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -20,7 +20,8 @@ install() {
         mkfs.xfs \
         mkfs.vfat \
         mkswap \
-        nvme
+        nvme \
+        wipefs
 
     inst_script "$udevdir/cloud_aws_ebs_nvme_id" \
         "/usr/lib/udev/cloud_aws_ebs_nvme_id"


### PR DESCRIPTION
It's required to run ignition/v3 since this commit: https://github.com/coreos/ignition/pull/991/commits/894e2a4bcd1dd1738b81a521dff2f3b4324cd9e8

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

Otherwise, if `wipeFilesystem: true` was in the config, `ignition` was failing because `wipefs` is not present in the initramfs.