### PR TITLE
network: Enable the RAs to fix IPv6 address assignment

### DIFF
--- a/changelog/bugfixes/2022-01-14-enable-icmpv6-router-adverts.md
+++ b/changelog/bugfixes/2022-01-14-enable-icmpv6-router-adverts.md
@@ -1,0 +1,1 @@
+- network: Enable the ICMPv6 RAs to fix IPv6 address assignment ([PR#30](https://github.com/flatcar-linux/bootengine/pull/30))

--- a/dracut/03flatcar-network/parse-ip-for-networkd.sh
+++ b/dracut/03flatcar-network/parse-ip-for-networkd.sh
@@ -79,7 +79,7 @@ for p in $(getargs ip=); do
     [ -n "$mtu" ] && echo "MTUBytes=$mtu" >> $_net_file
     echo '[Network]' >> $_net_file
     [ "x$autoconf" = xoff -o "x$autoconf" = xnone ] &&
-        echo DHCP=no >> $_net_file || echo DHCP=yes >> $_net_file
+        echo DHCP=no >> $_net_file || echo -e "DHCP=yes\nIPv6AcceptRA=true" >> $_net_file
     [ -n "$gw" ] && echo "Gateway=$gw" >> $_net_file
     [ -n "$dns1" ] && echo "DNS=$dns1" >> $_net_file
     [ -n "$dns2" ] && echo "DNS=$dns2" >> $_net_file

--- a/dracut/03flatcar-network/yy-digitalocean-coreos.network
+++ b/dracut/03flatcar-network/yy-digitalocean-coreos.network
@@ -5,3 +5,4 @@ Name=eth0
 [Network]
 DHCP=yes
 LinkLocalAddressing=yes
+IPv6AcceptRA=true

--- a/dracut/03flatcar-network/yy-digitalocean.network
+++ b/dracut/03flatcar-network/yy-digitalocean.network
@@ -5,3 +5,4 @@ Name=eth0
 [Network]
 DHCP=yes
 LinkLocalAddressing=yes
+IPv6AcceptRA=true

--- a/dracut/03flatcar-network/yy-netroot.network
+++ b/dracut/03flatcar-network/yy-netroot.network
@@ -5,6 +5,7 @@ KernelCommandLine=netroot
 DHCP=yes
 # Root is on the network, it can't go down at switch-root
 KeepConfiguration=yes
+IPv6AcceptRA=true
 
 [DHCP]
 UseMTU=true

--- a/dracut/03flatcar-network/yy-pxe.network
+++ b/dracut/03flatcar-network/yy-pxe.network
@@ -4,6 +4,7 @@ KernelCommandLine=!root
 
 [Network]
 DHCP=yes
+IPv6AcceptRA=true
 
 [DHCP]
 ClientIdentifier=mac

--- a/dracut/03flatcar-network/zz-default.network
+++ b/dracut/03flatcar-network/zz-default.network
@@ -4,6 +4,7 @@ Type=!loopback
 
 [Network]
 DHCP=yes
+IPv6AcceptRA=true
 
 [DHCP]
 UseMTU=true


### PR DESCRIPTION
The IPv6 address are currently not automatically assigned due to the absence
of the `IPv6AcceptRA` configuration.

Signed-off-by: Sayan Chowdhury <schowdhury@microsoft.com>
