### PR TITLE
dracut: Stop using deprecated actions in veritysetup

### DIFF
--- a/dracut/10verity-generator/verity-generator
+++ b/dracut/10verity-generator/verity-generator
@@ -75,13 +75,13 @@ if [[ -n "${usr}" && -n "${usrhash}" ]]; then
 	Type=oneshot
 	RemainAfterExit=yes
 	# Try to query the filesystem size dynamically but otherwise fall back to the expected value from the image GPT layout
-	ExecStart=/bin/sh -c '/sbin/veritysetup create usr --panic-on-corruption --hash-offset="\$(e2size ${usr} || echo 1065345024)" "${usr}" "${usr}" "${usrhash}"'
+	ExecStart=/bin/sh -c '/sbin/veritysetup --panic-on-corruption --hash-offset="\$(e2size ${usr} || echo 1065345024)" open "${usr}" usr "${usr}" "${usrhash}"'
 	# If there's a hash mismatch during table initialization,
 	# veritysetup reports it on stderr but still exits 0, and
 	# dev-mapper-usr.device ends up waiting indefinitely. Manually
 	# check the target status and fail if invalid.
 	ExecStart=/bin/bash -c 'read off len tgt status addl <<<\$(dmsetup status usr); [[ "\$\${status}" == V ]]'
-	ExecStop=/sbin/veritysetup remove usr
+	ExecStop=/sbin/veritysetup close usr
 	EOF
 
     requires_dir="${UNIT_DIR}/dev-mapper-usr.device.requires"

--- a/update-bootengine
+++ b/update-bootengine
@@ -33,7 +33,7 @@ DRACUT_ARGS=(
     --omit lvm
     --omit multipath
     --omit network
-    -a iscsi
+    --add iscsi
     )
 
 SETUP_MOUNTS=


### PR DESCRIPTION
The "create" action became "open", and "remove" became "close". Also
reorder the parameters accordingly (it's a bit different for "open" vs
"create"). Also put the options before specifying the action.

CI: http://localhost:9091/job/os/job/manifest/4066/cldsv/