### PR TITLE
update-bootengine: make dracut install loop driver

### DIFF
--- a/changelog/bugfixes/2021-12-23-add-loop-driver.md
+++ b/changelog/bugfixes/2021-12-23-add-loop-driver.md
@@ -1,0 +1,1 @@
+- Make dracut explicitly install the loop kernel module to fix booting issues with Kernel 5.15. ([PR#32](https://github.com/flatcar-linux/bootengine/pull/32))

--- a/update-bootengine
+++ b/update-bootengine
@@ -34,6 +34,7 @@ DRACUT_ARGS=(
     --omit multipath
     --omit network
     --add iscsi
+    --add-drivers loop
     )
 
 SETUP_MOUNTS=


### PR DESCRIPTION
Unlike with Kernel 5.10, dracut does not automatically install `loop.ko` with Kernel 5.15.
Explicitly install the loop module from the dracut command line.

## Testing done

CI passed for amd64: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4434/cldsv/

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
