### PR TITLE
dracut/99emergency-timeout/timeout.sh: fix heredoc leak into arguments

### DIFF
--- a/dracut/99emergency-timeout/timeout.sh
+++ b/dracut/99emergency-timeout/timeout.sh
@@ -40,7 +40,8 @@ _prompt_for_timeout() {
         _wait_for_journalctl_to_stop
 
         # Print Ignition logs
-        cat <<EOF -------------------------------------------------------------------------------
+        cat <<EOF
+-------------------------------------------------------------------------------
 Ignition has failed. Please ensure your config is valid.
 A CLI validation tool for this called ignition-validate can be downloaded from GitHub:
     https://github.com/coreos/ignition/releases

--- a/dracut/99emergency-timeout/timeout.sh
+++ b/dracut/99emergency-timeout/timeout.sh
@@ -45,7 +45,8 @@ _prompt_for_timeout() {
 Ignition has failed. Please ensure your config is valid.
 A CLI validation tool for this called ignition-validate can be downloaded from GitHub:
     https://github.com/coreos/ignition/releases
-An online validator is also available at coreos.com/validate
+A more generic validator is also available at:
+    https://github.com/kinvolk/container-linux-userdata-validator
 Here are the Ignition logs:
 EOF
         journalctl -t ignition --no-pager --no-hostname -o cat


### PR DESCRIPTION
- dracut/99emergency-timeout/timeout.sh: fix heredoc leak into arguments
    
    The content that was supposed to be in the heredoc got interpreted as
    parameters for "cat", causing it to fail.
    Move the separator dahes into the next line to make sure it gets
    treated as heredoc content.
- dracut/99emergency-timeout/timeout.sh: replace old CoreOS link
    
    The old CoreOS online validator does not have a new Flatcar home yet.
    Use the repo link for the binary of it instead.

## How to use
Create coreos-overlay PR to update the commit reference and add the changelog there

## Testing done

None, just manual execution of the moved line

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ Not done here, should be done in the coreos-overlay PR that pulls it in