### PR TITLE
support flag file to runtime switch to cgroupv1

### DIFF
--- a/dracut/99switch-root/initrd-parse-etc-override.conf
+++ b/dracut/99switch-root/initrd-parse-etc-override.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPost=-/bin/sh -c "[ -f /sys/fs/cgroup/cgroup.subtree_control ] && [ -f /sysroot/etc/flatcar-cgroupv1 ] && echo INIT=/sbin/init.wrapper >/etc/switch-root.env"

--- a/dracut/99switch-root/module-setup.sh
+++ b/dracut/99switch-root/module-setup.sh
@@ -11,4 +11,6 @@ install() {
         "${systemdsystemunitdir}/initrd-switch-root.service.d/override.conf"
     inst_simple "${moddir}/initrd-parse-etc-override.conf" \
         "${systemdsystemunitdir}/initrd-parse-etc.service.d/override.conf"
+    inst_simple "${moddir}/nocgroup.conf" \
+        "/etc/systemd/system.conf.d/nocgroup.conf"
 }

--- a/dracut/99switch-root/module-setup.sh
+++ b/dracut/99switch-root/module-setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+depends() {
+    echo systemd
+}
+
+install() {
+    inst_simple "${moddir}/override.conf" \
+        "${systemdsystemunitdir}/initrd-switch-root.service.d/override.conf"
+    inst_simple "${moddir}/initrd-parse-etc-override.conf" \
+        "${systemdsystemunitdir}/initrd-parse-etc.service.d/override.conf"
+}

--- a/dracut/99switch-root/nocgroup.conf
+++ b/dracut/99switch-root/nocgroup.conf
@@ -1,0 +1,7 @@
+[Manager]
+DefaultCPUAccounting=no
+DefaultIOAccounting=no
+DefaultIPAccounting=no
+DefaultBlockIOAccounting=no
+DefaultMemoryAccounting=no
+DefaultTasksAccounting=no

--- a/dracut/99switch-root/override.conf
+++ b/dracut/99switch-root/override.conf
@@ -1,0 +1,6 @@
+[Service]
+Type=oneshot
+Environment=INIT=
+EnvironmentFile=-/etc/switch-root.env
+ExecStart=
+ExecStart=systemctl --no-block switch-root /sysroot $INIT


### PR DESCRIPTION
# support flag file to runtime switch to cgroupv1

The idea is to detect the presence of a flag file (`/etc/flatcar-cgroupv1`), to call `systemctl switch-root` with `init.wrapper` as an argument. `init.wrapper` takes care of unmounting the currently mounted cgroup after initramfs, allowing sysroot systemd to remount cgroupv1.

The detection is done at the end of initrd-parse-etc.service, and the parameters are passed to initrd-switch-root.service through a temporary environment file.

## How to use

To be used with https://github.com/flatcar-linux/init/pull/62.

## Testing done

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
