### PR TITLE
update-bootengine: fix containerised builds

### DIFF
--- a/update-bootengine
+++ b/update-bootengine
@@ -103,6 +103,11 @@ else
     DRACUT_ARGS+=( "--no-kernel" )
 fi
 
+# Copying / installing files to initrd while preserving xattrs breaks dracut in certain scenarios,
+#  e.g. when run in a container.
+DRACUT_NO_XATTR=1
+export DRACUT_NO_XATTR
+
 mkdir -p "${USE_CHROOT}$(dirname "$CPIO_PATH")"
 if [[ -n "$USE_CHROOT" ]]; then
     echo "Running dracut in $USE_CHROOT"


### PR DESCRIPTION
This is a back-port of https://github.com/flatcar-linux/bootengine/pull/36 on top of the `bootengine` version [used in flatcar-3066](https://github.com/flatcar-linux/coreos-overlay/blob/flatcar-3066/sys-kernel/bootengine/bootengine-9999.ebuild). It will require a follow-up PR to the 3066 maintenance branch in coreos-overlay.

dracut, when copying (installing( files into the initrd image, preserves xattrs by default. Docker containers use overlayfs, which does not support some extended attributes.
When creating an initrd in a containerised build, dracut prints a number of warnings and errors, and the resulting initrd is subtly broken (e.g. soft-links aren't installed).

This patch sets the DRACUT_NO_XATTR env variable to prevent dracut from trying to preserve xattrs while copying.

We have validated in both the containerised SDK as well as in the cork-based chroot SDK that no xattrs are used in /build/* by means of

    sudo find /build/amd64-usr/ -type f -exec getfattr -d {} \;

which came up empty.