### PR TITLE
dracut/ignition: convert "gce" to "gcp"

### DIFF
--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -151,4 +151,9 @@ if [ "${oem_cmdline}" = "ec2" ]; then
   oem_cmdline="aws"
 fi
 
+# Ignition changed the platform name to "gcp"
+if [ "${oem_cmdline}" = "gce" ]; then
+  oem_cmdline="gcp"
+fi
+
 { echo "OEM_ID=${oem_cmdline}" ; echo "PLATFORM_ID=${oem_cmdline}" ; } > /run/ignition.env


### PR DESCRIPTION
upstream ignition renamed gce to gcp, so convert it to ensure
compatibility.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>
