### PR TITLE
update-bootengine: add missing kernel modules back

### DIFF
--- a/update-bootengine
+++ b/update-bootengine
@@ -34,7 +34,7 @@ DRACUT_ARGS=(
     --omit multipath
     --omit network
     --add iscsi
-    --add-drivers loop
+    --add-drivers "loop brd drbd nbd rbd xen-blkfront zram libarc4 lru_cache zsmalloc"
     )
 
 SETUP_MOUNTS=


### PR DESCRIPTION
Compared to Flatcar major version 3033 these modules went missing from
the initramfs:
glue_helper.ko.xz md4.ko.xz aoe.ko.xz brd.ko.xz drbd.ko.xz nbd.ko.xz
rbd.ko.xz xen-blkfront.ko.xz zram.ko.xz pps_core.ko.xz ptp.ko.xz
nfs_ssc.ko.xz libarc4.ko.xz lru_cache.ko.xz zsmalloc.ko.xz
The "loop" module already was added because PXE boots broke. The
xen-blkfront module however also broke booting on m4 AWS EC2 instances.
Add those modules from the above list back to the initramfs which are
present on the 5.15 kernel.

## How to use

Build and test booting on m4 instances, but it also requires the kernel commit revert for networking

## Testing done
Tested that the initramfs has the modules now (unpack Stable 3033.2.3 and this build's vmlinuz with `extract-initramfs-from-vmlinuz.sh` and look that things like zram.ko.xz don't appear on the left sdiff side but not on the right. Also check dracut logs from coreos-kernel.
```
sdiff -s  <(ls -R vmlinuz-stable-unpacked/|grep ko.xz|sort) <(ls -R fixed-vmlinuz-unpacked/|grep ko.xz|sort)
							      >	acpi_mdio.ko.xz
aoe.ko.xz						      <
							      >	asn1_encoder.ko.xz
							      >	ax88796b.ko.xz
							      >	cifs_arc4.ko.xz
							      >	cifs_md4.ko.xz
							      >	des_generic.ko.xz
							      >	fixed_phy.ko.xz
							      >	fwnode_mdio.ko.xz
glue_helper.ko.xz					      <
							      >	mana.ko.xz
md4.ko.xz						      <
mlxsw_switchib.ko.xz					      <
mlxsw_switchx2.ko.xz					      <
							      >	netfs.ko.xz
nfs_ssc.ko.xz						      <
pps_core.ko.xz						      <
ptp.ko.xz						      <
							      >	scsi_common.ko.xz
							      >	selftests.ko.xz

```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ in coreos-overlay