### PR TITLE
dracut/ignition: add cryptsetup to initramfs

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -41,7 +41,8 @@ install() {
         useradd \
         userdel \
         usermod \
-        wipefs
+        wipefs \
+        cryptsetup
 
     # Flatcar: add cloud_aws_ebs_nvme_id
     inst_script "$udevdir/cloud_aws_ebs_nvme_id" \


### PR DESCRIPTION
Without this dependency, Ignition
is not able to create statically-keyed data volumes.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

```
disks: createLuks: op(3): executing: "cryptsetup" "luksFormat" "--type" "luks2" "--key-file" "/tmp/ignition-luks-2450372113" "/run/ignition/dev_aliases/dev/vda6"
disks: createLuks: op(3): [failed]   creating "data": exec: "cryptsetup": executable file not found in $PATH: Cmd: "cryptsetup" "luksFormat" "--type" "luks2" "--key-file" "/tmp/ignition-luks-2450372113" "/run/ignition/dev_aliases/dev/vda6" Stdout: "" Stderr: ""
```

I'm just concerned by the final size of the initramfs

Changelog entry will be added on ::coreos-overlay side.
