### PR TITLE
dracut/ignition: add setfiles to initramfs

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -42,7 +42,8 @@ install() {
         userdel \
         usermod \
         wipefs \
-        cryptsetup
+        cryptsetup \
+        setfiles
 
     # Flatcar: add cloud_aws_ebs_nvme_id
     inst_script "$udevdir/cloud_aws_ebs_nvme_id" \


### PR DESCRIPTION
# dracut/ignition: add setfiles to initramfs

The intention is to enable ignition to relabel files.

Related Bug: https://github.com/flatcar-linux/Flatcar/issues/673