### PR TITLE
Remove afterburn /etc/hostname setup for EC2 and align it with upstream

### DIFF
--- a/dracut/30ignition/flatcar-digitalocean-network.service
+++ b/dracut/30ignition/flatcar-digitalocean-network.service
@@ -7,4 +7,4 @@ Wants=systemd-networkd.service initrd-root-fs.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/coreos-metadata --cmdline --network-units=/run/systemd/network/ --hostname=/sysroot/etc/hostname
+ExecStart=/usr/bin/coreos-metadata --cmdline --network-units=/run/systemd/network/

--- a/dracut/30ignition/flatcar-metadata-hostname.service
+++ b/dracut/30ignition/flatcar-metadata-hostname.service
@@ -8,6 +8,33 @@ Wants=systemd-networkd.service initrd-root-fs.target
 # Ensure Ignition can overwrite /etc/hostname
 Before=ignition-files.service
 
+# From coreos/afterburn:dracut/30afterburn/afterburn-hostname.service
+# (but with coreos.oem.id/flatcar.oem.id):
+# These platforms do not provide the hostname via DHCP
+# options, thus it needs to be fetched from the metadata
+# and statically applied on first-boot.
+ConditionKernelCommandLine=|coreos.oem.id=aliyun
+ConditionKernelCommandLine=|flatcar.oem.id=aliyun
+ConditionKernelCommandLine=|coreos.oem.id=azure
+ConditionKernelCommandLine=|flatcar.oem.id=azure
+ConditionKernelCommandLine=|coreos.oem.id=azurestack
+ConditionKernelCommandLine=|flatcar.oem.id=azurestack
+ConditionKernelCommandLine=|coreos.oem.id=digitalocean
+ConditionKernelCommandLine=|flatcar.oem.id=digitalocean
+ConditionKernelCommandLine=|coreos.oem.id=exoscale
+ConditionKernelCommandLine=|flatcar.oem.id=exoscale
+ConditionKernelCommandLine=|coreos.oem.id=ibmcloud
+ConditionKernelCommandLine=|flatcar.oem.id=ibmcloud
+ConditionKernelCommandLine=|coreos.oem.id=vultr
+ConditionKernelCommandLine=|flatcar.oem.id=vultr
+# Addition:
+ConditionKernelCommandLine=|coreos.oem.id=packet
+ConditionKernelCommandLine=|flatcar.oem.id=packet
+
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/coreos-metadata --cmdline --hostname=/sysroot/etc/hostname
+RemainAfterExit=yes

--- a/dracut/30ignition/flatcar-static-network.service
+++ b/dracut/30ignition/flatcar-static-network.service
@@ -10,4 +10,4 @@ Before=ignition-files.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/coreos-metadata --cmdline --network-units=/sysroot/etc/systemd/network/ --hostname=/sysroot/etc/hostname
+ExecStart=/usr/bin/coreos-metadata --cmdline --network-units=/sysroot/etc/systemd/network/

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -69,9 +69,8 @@ Conflicts=emergency.service
 Conflicts=dracut-emergency.service
 EOF
     fi
-    if [[ $(cmdline_arg flatcar.oem.id) == "ec2" ]] || [[ $(cmdline_arg coreos.oem.id) == "ec2" ]]; then
-        add_wants flatcar-metadata-hostname.service
-    fi
+    # Configure hostname from metadata through afterburn on platforms that don't set it via DHCP
+    add_wants flatcar-metadata-hostname.service
     if [[ $(cmdline_arg flatcar.oem.id) == "openstack" ]] || [[ $(cmdline_arg coreos.oem.id) == "openstack" ]]; then
         add_wants flatcar-openstack-hostname.service
     fi


### PR DESCRIPTION
The hostname afterburn got from the EC2 metadata was a FQDN and too
long. We actually don't need afterburn to set the hostname because it
is also set up via DHCP. Also, the upstream afterburn-hostname.service
already has conditions to run on the right platforms. We can use these
instead of custom shell logic.

Align flatcar-metadata-hostname.service with upstream afterburn and
don't use it for EC2. Adapt the upstream unit to fit our needs with a
different cmdline arg naming and skip the relabling workaround
(for now).

Fixes https://github.com/flatcar-linux/Flatcar/issues/707


## How to use


## Testing done

Test results in https://github.com/flatcar-linux/coreos-overlay/pull/1817

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ TODO in c-o