### PR TITLE
dracut: add network kargs service

### DIFF
--- a/dracut/03flatcar-network/afterburn-network-kargs.service
+++ b/dracut/03flatcar-network/afterburn-network-kargs.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Afterburn Initrd Setup Network Kernel Arguments
+Documentation=https://coreos.github.io/afterburn/usage/initrd-network-cmdline/
+
+# This service may produce additional kargs fragments,
+# which are then consumed by dracut-cmdline(8).
+DefaultDependencies=no
+Before=dracut-cmdline.service systemd-networkd.service
+PartOf=systemd-networkd.service
+# For extra safety
+ConditionKernelCommandLine=|coreos.oem.id=vmware
+ConditionKernelCommandLine=|flatcar.oem.id=vmware
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+[Service]
+ExecStart=/usr/bin/coreos-metadata exp rd-network-kargs --cmdline --default-value ''
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=systemd-networkd.service

--- a/dracut/03flatcar-network/module-setup.sh
+++ b/dracut/03flatcar-network/module-setup.sh
@@ -10,6 +10,8 @@ depends() {
 
 # called by dracut
 install() {
+    inst_multiple coreos-metadata
+
     inst_multiple -o \
         $systemdutildir/systemd-resolved \
         $systemdsystemunitdir/systemd-resolved.service \
@@ -17,6 +19,9 @@ install() {
 
     inst_simple "$moddir/network-cleanup.service" \
         "$systemdsystemunitdir/network-cleanup.service"
+
+    inst_simple "$moddir/afterburn-network-kargs.service" \
+        "$systemdsystemunitdir/afterburn-network-kargs.service"
 
     inst_simple "$moddir/10-nodeps.conf" \
         "$systemdsystemunitdir/systemd-resolved.service.d/10-nodeps.conf"
@@ -56,4 +61,5 @@ install() {
     systemctl --root "$initdir" disable systemd-networkd.socket
 
     systemctl --root "$initdir" enable network-cleanup.service
+    systemctl --root "$initdir" enable afterburn-network-kargs.service
 }


### PR DESCRIPTION
This service allows to read cmdline to inject network configuration as initrd kargs.

See also: https://github.com/flatcar-linux/mantle/pull/329

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (-> coreos-overlay)
