### PR TITLE
ignition: default to 'metal' OEM

### DIFF
--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -135,7 +135,7 @@ if [[ $(cmdline_arg flatcar.oem.id) == "digitalocean" ]] || [[ $(cmdline_arg cor
     add_requires flatcar-digitalocean-network.service initrd.target
 fi
 
-oem_id=pxe
+oem_id=metal
 if [[ $(systemd-detect-virt || true) =~ ^(kvm|qemu)$ ]]; then
     oem_id=qemu
 fi
@@ -153,6 +153,11 @@ fi
 # Ignition changed the platform name to "gcp"
 if [ "${oem_cmdline}" = "gce" ]; then
   oem_cmdline="gcp"
+fi
+
+# To maintain compatibility with eventual legacy 'flatcar.oem.id=pxe'
+if [ "${oem_cmdline}" = "pxe" ]; then
+  oem_cmdline="metal"
 fi
 
 { echo "OEM_ID=${oem_cmdline}" ; echo "PLATFORM_ID=${oem_cmdline}" ; } > /run/ignition.env


### PR DESCRIPTION
With Ignition upgrade, `pxe` is no more a supported platform and it's
replaced by `metal` platform.

According to the documentation, it's the same mechanism:
> Bare Metal (metal) - Use the ignition.config.url kernel parameter to provide a URL to the configuration. The URL can use the http://, https://, tftp://, s3://, arn:, or gs:// schemes to specify a remote config.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

changelog will be added in the overlay 
