### PR TITLE
Add dracut module to persist SELinux base policy from image on boot

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -67,6 +67,9 @@ install() {
     # Required on system using SELinux
     inst_multiple -o setfiles
 
+    inst_script "$moddir/selinux-policy-persist" \
+        "/usr/sbin/selinux-policy-persist"
+
     inst_script "$moddir/ignition-kargs-helper" \
         "/usr/sbin/ignition-kargs-helper"
 

--- a/dracut/30ignition/selinux-policy-persist
+++ b/dracut/30ignition/selinux-policy-persist
@@ -8,8 +8,8 @@
 set -euxo pipefail
 
 # Remove pre-existing policies.
-rm /etc/selinux/mcs
-rm /var/lib/selinux
+rm -rf /etc/selinux/mcs
+rm -rf /var/lib/selinux
 
 # install policies from image. Making them read/write.
 cp -a /usr/lib/selinux/mcs /etc/selinux

--- a/dracut/30ignition/selinux-policy-persist
+++ b/dracut/30ignition/selinux-policy-persist
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Allows for auto-updating the SELinux base policy
+# while keeping the policy directory that's running
+# on the node read/write. e.g. allowing installation
+# of non-reboot-persistent custom SELinux modules.
+
+set -euxo pipefail
+
+# Remove pre-existing policies.
+rm /etc/selinux/mcs
+rm /var/lib/selinux
+
+# install policies from image. Making them read/write.
+cp -a /usr/lib/selinux/mcs /etc/selinux
+cp -a /usr/lib/selinux/policy /var/lib/selinux
+
+# Build and reload policy
+semodule -DB


### PR DESCRIPTION
# Add dracut module to persist SELinux base policy from image on boot

The idea is that Flatcar ships and updates the base policy, which gets
persisted (and not as a symlink) on the initramfs. Flatcar users will
then need to run a custom systemd unit to install any custom modules
needed.
