### PR TITLE
ignition-kargs-helper: Ensure that grub.cfg exists before reading

### DIFF
--- a/dracut/30ignition/ignition-kargs-helper
+++ b/dracut/30ignition/ignition-kargs-helper
@@ -18,6 +18,9 @@ oemdev=/dev/disk/by-label/OEM
 mount -o rw ${oemdev} ${oemmnt}
 grubcfg="${oemmnt}/grub.cfg"
 
+# Ensure that it exists before we read from it (needed for the generic Flatcar image), "touch" does not exist in initramfs
+true >> $grubcfg
+
 # We do not handle all cases of conditional setup of linux_append or linux_console because we will not emulate the GRUB scripting logic.
 # Therefore, we only support the special lines 'set linux_append="($linux_append) ..."' which must not be starting with whitespace and should not be surrounded by an if-block.
 # Any conditional setup before or afterwards or the values of linux_console are not considered.


### PR DESCRIPTION
The kola kargs test fails for the generic image when it's not mangled
(which is the kola term for setting the console option by creating the
grub.cfg file) because the kargs helper didn't handle the case where
the file doesn't exist which is normal for the generic image.
Create the grub.cfg file if it doesn't exist before trying to read from
it.

## How to use

We can backport it on the bootengine backport branches

## Testing done

[build](http://192.168.42.7:8080/job/container/job/packages/805/cldsv/)
- tested manually setting `--qemu-skip-mangle` as kola flag
-  and using the qemu script with this test Ignition config:
```
{
  "ignition": {
    "version": "3.3.0"
  },
  "kernelArguments": {
    "shouldExist": ["flatcar.autologin"]
  }
}
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑  in coreos-overlay