### PR TITLE
initrd-setup-root: Run always to ensure rootfs is populated

### DIFF
--- a/dracut/30ignition/ignition-complete.target
+++ b/dracut/30ignition/ignition-complete.target
@@ -9,6 +9,10 @@ Documentation=https://github.com/coreos/ignition
 ConditionPathExists=/etc/initrd-release
 Before=initrd.target
 
+# Run the generic rootfs setup helpers
+Requires=initrd-setup-root.service
+After=initrd-setup-root.service
+
 # Make sure we stop all the units before switching root
 Conflicts=initrd-switch-root.target umount.target
 Conflicts=dracut-emergency.service emergency.service emergency.target

--- a/dracut/30ignition/ignition-subsequent.target
+++ b/dracut/30ignition/ignition-subsequent.target
@@ -7,6 +7,10 @@ Documentation=https://github.com/coreos/ignition
 ConditionPathExists=/etc/initrd-release
 Before=initrd.target
 
+# Run the generic rootfs setup helpers
+Requires=initrd-setup-root.service
+After=initrd-setup-root.service
+
 # Make sure we stop all the units before switching root
 Conflicts=initrd-switch-root.target umount.target
 Conflicts=dracut-emergency.service emergency.service emergency.target

--- a/dracut/99setup-root/initrd-setup-root
+++ b/dracut/99setup-root/initrd-setup-root
@@ -2,6 +2,11 @@
 # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
+# Safe to run also after an official first boot and we do this now
+# for consistency regardless if first_boot= is passed to create missing
+# files if needed and make it easier to debug. In fact, it was required
+# to use first_boot=1 with PXE to get a proper rootfs which is strange.
+
 # /etc/machine-id after a new image is created:
 COREOS_BLANK_MACHINE_ID="42000000000000000000000000000042"
 MACHINE_ID_FILE="/sysroot/etc/machine-id"

--- a/dracut/99setup-root/initrd-setup-root.service
+++ b/dracut/99setup-root/initrd-setup-root.service
@@ -2,11 +2,13 @@
 Description=Root filesystem setup
 DefaultDependencies=no
 RequiresMountsFor=/sysroot/usr/
-RequiresMountsFor=/sysroot/usr/share/oem
-After=sysroot-usr.mount
 After=initrd-root-fs.target
 Before=initrd-parse-etc.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/sbin/initrd-setup-root
+
+[Install]
+WantedBy=initrd.target

--- a/dracut/99setup-root/module-setup.sh
+++ b/dracut/99setup-root/module-setup.sh
@@ -15,7 +15,4 @@ install() {
     inst_simple "${moddir}/initrd-setup-root.service" \
         "${systemdsystemunitdir}/initrd-setup-root.service"
 
-    mkdir -p "${systemdsystemunitdir}/initrd.target.wants"
-    ln_r "${systemdsystemunitdir}/initrd-setup-root.service" \
-        "${systemdsystemunitdir}/initrd.target.wants/initrd-setup-root.service"
 }


### PR DESCRIPTION
In https://github.com/flatcar/Flatcar/issues/944 we noticed that dbus failed because of missing files in the rootfs when Ignition isn't running in a PXE environment. This worked before by chance but the underlying problem is that initrd-setup-root is required but wasn't running because the "wants" symlinks in the module setup weren't taking effect.

This is a backport of the relevant changes in
https://github.com/flatcar/bootengine/pull/50 to always run initrd-setup-root instead of only when Ignition runs by pulling it in from the two possible targets: either ignition-complete or ignition-subsequent which runs in the other case.
The RequiresMountsFor=/sysroot/usr/share/oem directive didn't have any effect because there was no mount unit defined. The directive After=sysroot-usr.mount is already implied by
RequiresMountsFor=/sysroot/usr/.


## How to use


## Testing done

see https://github.com/flatcar/coreos-overlay/pull/2371

