### PR TITLE
setup-root: Create overlay mount for /etc to provide files from /usr

### DIFF
--- a/dracut/99setup-root/initrd-setup-root
+++ b/dracut/99setup-root/initrd-setup-root
@@ -14,26 +14,22 @@ MACHINE_ID_FILE="/sysroot/etc/machine-id"
 # This creates the modifiable users/groups in /sysroot/etc,
 # initializing the shadow database in the process. This needs to
 # happen early, so systemd-tmpfiles can read the user info from
-# /sysroot.
+# /sysroot and Ignition can operate on these users.
 /usr/sbin/flatcar-tmpfiles /sysroot
 
-# Initialize base filesystem
+# Initialize base filesystem without /etc
 systemd-tmpfiles --root=/sysroot --create \
-    baselayout.conf baselayout-etc.conf baselayout-usr.conf \
-    baselayout-home.conf etc.conf etc-shadow.conf
-
-# Not all images provide these files so check before using them.
-# Note: selinux-base.conf must run before libsemanage.conf
-for config in baselayout-ldso.conf selinux-base.conf libsemanage.conf; do
-    if [ -e "/sysroot/usr/lib/tmpfiles.d/${config}" ]; then
-        systemd-tmpfiles --root=/sysroot --create "${config}"
-    fi
-done
+    baselayout.conf baselayout-usr.conf \
+    baselayout-home.conf
 
 # Remove our phony id. systemd will initialize this during boot.
 if grep -qs "${COREOS_BLANK_MACHINE_ID}" "${MACHINE_ID_FILE}"; then
     rm "${MACHINE_ID_FILE}"
 fi
+
+# Set up overlay mount for /etc (as long as we can't use syscfg for that)
+mkdir -p /sysroot/.etc-work
+mount -t overlay overlay -o lowerdir=/sysroot/usr/share/flatcar/etc,upperdir=/sysroot/etc,workdir=/sysroot/.etc-work,redirect_dir=on,metacopy=off,noatime /sysroot/etc
 
 # PXE initrds may provide OEM
 if [ -d /usr/share/oem ] && mountpoint --quiet /sysroot/usr/share/oem; then

--- a/dracut/99setup-root/initrd-setup-root-after-ignition.service
+++ b/dracut/99setup-root/initrd-setup-root-after-ignition.service
@@ -2,7 +2,7 @@
 Description=Root filesystem completion
 DefaultDependencies=no
 RequiresMountsFor=/sysroot/usr/ /sysroot/usr/share/oem/
-After=initrd-root-fs.target ignition-files.service
+After=initrd-root-fs.target ignition-files.service initrd-setup-root.service
 Before=initrd-parse-etc.service
 
 [Service]


### PR DESCRIPTION
The existing tmpfile logic took care of folders that the ebuild keepdir directive wanted to exist on the OS. However, files and symlinks were not created, causing them to be missing if we didn't explicitly modify the ebuild files in coreos-overlay to use tmpfiles or patching of paths to be in /usr. We need a logic to provide /etc files from the current /usr partition without getting stale. This can be done best with an overlay mount which requires to keep the original /etc files under /usr.
Set up an overlay mount from the initrd after basic root fs preparation (ensure that the user db and machine-id file are as expected and create non-/etc tmpfiles). What we get with an overlay mount is essentially a similar behavior to a 3-way merge because as long as the user didn't change the files, the old version is replaced with the new version and as soon as the user did changes, that file is frozen and wins over the provided old (in case of a rollback) or new versions from /usr. It does not work on file lines but on whole file contents, yet that is also what rpm-ostree does to my knowledge.

## How to use

Follow-up: I would like to add a boot cleanup action before setting up the mount, and it should remove duplicate files to keep the `/etc` folder clean and actually make use of the up-to-date lower files from `/usr/share/flatcar/etc`. ← But not a blocker from my point of view

Follow-up (mantle repo): Write a kola test that checks for unexpected upcopies (for now I did manual checks)

Follow-up: We should identify what downstream modifications in `coreos-overlay` we can drop now to have config files in `/etc` for legacy software.

Note: We should find out why systemd-tmpfiles causes upcopies for `L` and `C` entries and see if we can avoid it - maybe even upstream. For now I committed a change in the scripts repo to drop some rules after we used them to create `/usr/share/flatcar/etc` via a `sed -i '/^[CLd] *\/etc\//d' /usr/lib/tmpfiles.d/*` but it would be nice to fix this upstream.



## Testing done

Jenkins kola tests [passed](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1356/cldsv/), locally I checked the contents by mounting the image after a boot.