### PR TITLE
initrd-setup-root: Add selective OS reset handling

### DIFF
--- a/dracut/99setup-root/initrd-setup-root
+++ b/dracut/99setup-root/initrd-setup-root
@@ -31,6 +31,36 @@ function walksysroot() {
 COREOS_BLANK_MACHINE_ID="42000000000000000000000000000042"
 MACHINE_ID_FILE="/sysroot/etc/machine-id"
 
+function selectiveosreset() {
+  local entry="/sysroot$1"
+  # Don't remove /sysroot itself
+  [ "${entry}" = "/sysroot" ] && return 0
+  [ "${entry}" = "/sysroot/" ] && return 0
+  # Don't remove the active /usr mount point
+  [ "${entry}" = "/sysroot/usr" ] && return 0
+  # Not really needed because find doesn't add a trailing slash but to be safe:
+  [ "${entry}" = "/sysroot/usr/" ] && return 0
+  if [ -d "${entry}" ]; then
+    # Try to delete dir, will fail if its contents are preserved
+    usrbin rmdir "${entry}" 2>/dev/null || true
+  else
+    # Delete file, Report wrong paths to nonexisting files or any other errors
+    # (journalctl -u initrd-setup-root) but don't hard fail the boot
+    rm "${entry}" || true
+  fi
+  true # Do not carry any last condition evaluation over as return code
+}
+
+# Do the selective OS reset as prepared by flatcar-reset
+if [ -s /sysroot/selective-os-reset ]; then
+  walksysroot / selectiveosreset -regextype egrep -not -regex "$(cat /sysroot/selective-os-reset)"
+  rm -f /sysroot/selective-os-reset
+  # Always remove the machine-id file because otherwise it's not a first boot.
+  # The previous value can be preserved through the systemd.machine_id=
+  # kernel parameter.
+  rm -f /sysroot/etc/machine-id
+fi
+
 # This creates the modifiable users/groups in /sysroot/etc,
 # initializing the shadow database in the process. This needs to
 # happen early, so systemd-tmpfiles can read the user info from


### PR DESCRIPTION
A reconfiguration of a system will lead to config drift is the local state isn't discarded. However, while this is possible with Ignition reformatting the rootfs, this big hammer is too disruptive. Introduce a way to perform a selective OS reset where a special file contains a regex for paths to preserve. This regex should be prepared by a helper tool like
  `flatcar-reset --keep-paths "/etc/ssh/" "/var/docker.*"`
that would assemble the regex to be
  `(/etc/ssh|/etc/ssh/.*|/var/docker.*)`
where the omitted slash at the end of the /etc/ssh/ is needed due to how "find" prints the paths, and the additional entry `ssh/.*` for the contents of /etc/ssh/ which would otherwise be deleted - but we should allow the user to use a final slash anyway instead of forcing the user to add `/.*` everywhere, thus the helper tool should take care of it. If the user wants to remove all contents but keep the empty dir, `^/etc/ssh` or `/etc/ssh$` or `(/etc/ssh)` or `/etc/(ssh)` would work to directly specify the wanted regex without the helper tool expanding it (see linked PR).

## How to use

Based on https://github.com/flatcar/bootengine/pull/54 - Rebase before merging

The helper tool is introduced in https://github.com/flatcar/init/pull/91

## Testing done

With the new `flatcar-reset` tool I checked that `sudo flatcar-reset --keep-machine-id --ignition-file my.ign --keep-paths '/etc/ssh/ssh_host_.*' /var/log` and a reboot will discard all state except the ssh host keys and the system logs, and will set up the `grub.cfg` cmdline for the machine ID and use the given Ignition file.

[CI](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1380/cldsv/)