### PR TITLE
initrd-setup-root: Make script more resilient and handle deleted passwd

### DIFF
--- a/dracut/99setup-root/initrd-setup-root
+++ b/dracut/99setup-root/initrd-setup-root
@@ -31,6 +31,11 @@ function walksysroot() {
 COREOS_BLANK_MACHINE_ID="42000000000000000000000000000042"
 MACHINE_ID_FILE="/sysroot/etc/machine-id"
 
+# Allow to rerun the script
+if usrbin mountpoint -q /sysroot/etc; then
+  umount /sysroot/etc
+fi
+
 function selectiveosreset() {
   local entry="/sysroot$1"
   # Don't remove /sysroot itself
@@ -65,6 +70,15 @@ fi
 # initializing the shadow database in the process. This needs to
 # happen early, so systemd-tmpfiles can read the user info from
 # /sysroot and Ignition can operate on these users.
+for DBFILE in passwd group shadow gshadow; do
+  # First, to be able to write to the files, check that the user
+  # didn't somehow delete the files at which point they are special
+  # character devices in the upperdir and to recreate the files we
+  # need to remove them first.
+  if [ -c "/sysroot/etc/${DBFILE}" ]; then
+    rm -f "/sysroot/etc/${DBFILE}"
+  fi
+done
 /usr/sbin/flatcar-tmpfiles /sysroot
 
 # Initialize base filesystem without /etc


### PR DESCRIPTION
A rerun from the initrd due to manual invocation could easily result in a failure of the mount if it is already mounted or in working on merged overlay files instead of only the upperdir. Another similar failure case is when this wrong usage or even a deletion of /etc/passwd on the booted system results in a wiped out entry for /etc/passwd (overlayfs uses a special character device in the upperdir) which flatcar-tmpfiles can't recreate.
Support these edge cases as they seemed to have worked before and it also makes development/debugging easier.


## How to use


## Testing done

[CI](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1415/cldsv/) plus manually:
- `sudo rm /etc/passwd` and then a reboot → things work
- in the initrd (kernel cmdline `rd.shell rd.break=pre-pivot`) a manual run of `/sbin/initrd-setup-root` and continued the boot with `exit`