### PR TITLE
dracut/ignition: add "setfiles" binary

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -130,4 +130,6 @@ install() {
         "/usr/bin/coreos-metadata"
     inst_script "$moddir/ignition-wrapper" \
         "/usr/bin/ignition"
+    inst_script "$moddir/setfiles-wrapper" \
+        "/usr/bin/setfiles"
 }

--- a/dracut/30ignition/setfiles-wrapper
+++ b/dracut/30ignition/setfiles-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/sbin/setfiles "$@"


### PR DESCRIPTION
this is required to run SELinux relabelling for ignition. This should increase the initramfs size by 1M.

<hr>

Originally sent by @JAORMX 