### PR TITLE
dracut/99setup-root: change owner of /run/log/journal

### DIFF
--- a/dracut/99start-root/module-setup.sh
+++ b/dracut/99start-root/module-setup.sh
@@ -4,7 +4,4 @@
 
 install() {
     inst_rules "$moddir/65-start-root.rules"
-
-    rm -f "$initdir/usr/lib/systemd/system/systemd-tmpfiles-setup.service"
-    rm -f "$initdir/usr/lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup.service"
 }

--- a/dracut/99start-root/module-setup.sh
+++ b/dracut/99start-root/module-setup.sh
@@ -4,4 +4,6 @@
 
 install() {
     inst_rules "$moddir/65-start-root.rules"
+
+    sed -i 's/After=local-fs.target /After=/' "$initdir/usr/lib/systemd/system/systemd-tmpfiles-setup.service"
 }


### PR DESCRIPTION
Give the correct ownernship otherwise the tmpfiles configuration will not apply because of mismatching machine-id - which makes "journalctl --user" to fail