### PR TITLE
initrd-setup-root: Set up more /var directories from packages

### DIFF
--- a/dracut/99setup-root/initrd-setup-root
+++ b/dracut/99setup-root/initrd-setup-root
@@ -82,9 +82,15 @@ done
 /usr/sbin/flatcar-tmpfiles /sysroot
 
 # Initialize base filesystem without /etc
+# Don't run all tmpfiles rules but only the essential ones
+# required to let systemd do its work correctly
+# (baselayout.conf must contain /var/log/journal for it to
+# be created early enough, base_image_var.conf has other
+# directories that packages installed). The rest will be
+# done later as usual through systemd-tmpfiles-setup.service.
 systemd-tmpfiles --root=/sysroot --create \
     baselayout.conf baselayout-usr.conf \
-    baselayout-home.conf
+    baselayout-home.conf base_image_var.conf
 
 # Remove our phony id. systemd will initialize this during boot.
 if grep -qs "${COREOS_BLANK_MACHINE_ID}" "${MACHINE_ID_FILE}"; then


### PR DESCRIPTION
The base_image_var.conf contents are generated during image build and
    don't originally come from tmpfiles rules but from package
    installation. For those rules coming from a package's tmpfiles I think
    t's enough to let them do the job at their regular boot stage but for
    those not from tmpfiles we don't really know whether this works for
    them, so I added it as precaution. Also, add info on where
    /var/log/journal gets set up.


## How to use

Backport to Alpha

## Testing done

[Done](http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/738/cldsv/)