### PR TITLE
setup-root: Detect initial sysext MVP

### DIFF
--- a/dracut/99setup-root/initrd-setup-root-after-ignition
+++ b/dracut/99setup-root/initrd-setup-root-after-ignition
@@ -13,6 +13,7 @@ OEMID=$({ grep -m 1 -o "^ID=.*" /sysroot/oem/oem-release || true ; } | cut -d = 
 
 # The active-oem-OEMID file gets created by the update-engine postinst action if both old and new /usr partitions have a sysext
 if [ "${OEMID}" != "" ] && [ -e "/sysroot/oem/sysext/active-oem-${OEMID}" ]; then
+  INITIAL_MVP="/oem/sysext/oem-${OEMID}-initial.raw"
   SYSEXT_OEM_PART="/oem/sysext/oem-${OEMID}-${VERSION}.raw"
   SYSEXT_ROOT_PART="/etc/flatcar/oem-sysext/oem-${OEMID}-${VERSION}.raw"
   SYMLINK="/sysroot/etc/extensions/oem-${OEMID}.raw"
@@ -41,6 +42,12 @@ if [ "${OEMID}" != "" ] && [ -e "/sysroot/oem/sysext/active-oem-${OEMID}" ]; the
       echo "That failed, keeping it on root partition" >&2
       ACTIVE_OEM="${SYSEXT_ROOT_PART}"
     fi
+  elif [ -e "/sysroot/${INITIAL_MVP}" ]; then
+    # This is the initial MVP OEM sysext that is not bound to the OS version because
+    # at that time update support was missing.
+    # Like any other inactive sysext, it will be deleted by update-engine's post-inst action
+    # when it's not needed (i.e., the active and new inactive both have a versioned sysext)
+    ACTIVE_OEM="${INITIAL_MVP}"
   else
     echo "Did not find ${SYSEXT_OEM_PART} nor ${SYSEXT_ROOT_PART}" >&2
     # TODO: Try to download it as fallback (needs starting and waiting for the network target), or maybe just give up and place a warning somewhere (motd?)

--- a/dracut/99setup-root/initrd-setup-root-after-ignition
+++ b/dracut/99setup-root/initrd-setup-root-after-ignition
@@ -63,7 +63,11 @@ if [ "${OEMID}" != "" ] && [ -e "/sysroot/oem/sysext/active-oem-${OEMID}" ]; the
   # Flag file created by the update-engine postinst action if both /usr partitions have a sysext and active-oem-OEMID didn't exist
   if [ -e "/sysroot/oem/sysext/migrate-oem-${OEMID}" ]; then
     echo "Found migration flag, deleting known old OEM partition files" >&2
-    # TODO: For each OEMID, delete known old files under /oem/ and /etc/
+    # For each OEMID, delete known old files under /oem/ and /etc/ based on the contents of the flag file
+    # (The list is maintained in the update-engine post-inst action)
+    while IFS="" read -r entry; do
+      rm -f "${entry}" || true
+    done < "/sysroot/oem/sysext/migrate-oem-${OEMID}"
     rm -f "/sysroot/oem/sysext/migrate-oem-${OEMID}"
   fi
 fi


### PR DESCRIPTION
- setup-root: Detect initial sysext MVP
    
    We have implemented the building of OEM sysext images but the update
    path is still in progress. Instead of blocking the migration for new
    deployments, we will lose the version coupling by using "initial" as
    version in the file name and SYSEXT_LEVEL instead of VERSION_ID for the
    extension release file.
    Detect the initial sysext MVP path to activate the OEM sysext.
- setup-root: Read old OEM files from the migration flag file
    
    The list of old files per OEM needs to be maintained somewhere. Instead
    of doing this in the initrd script, we can use the update-engine
    post-inst action which already is a place for migration logic.
    Expect that the post-inst action writes all old OEM files to clean up to
    the migration flag file that triggers the deletion.

## How to use

Requires changes in https://github.com/flatcar/scripts/pull/858/files#diff-3b2def625e0988b47d34144d412cb632e946cd13b7b57ad3918b4322cbef9262R165 to use SYSEXT_LEVEL and in https://github.com/flatcar/scripts/pull/858/files#diff-1390361e20f8ec710779da5680655da8aef20d972df05b5c0c4ca5e3ad80a1adR552 to overwrite the version to be `initial`

## Testing done

to be done with the scripts PR 

