### PR TITLE
setup-root: Prevent a bootloop on service failure

### DIFF
--- a/dracut/99setup-root/initrd-setup-root-after-ignition.service
+++ b/dracut/99setup-root/initrd-setup-root-after-ignition.service
@@ -4,6 +4,8 @@ DefaultDependencies=no
 RequiresMountsFor=/sysroot/usr/ /sysroot/oem/
 After=initrd-root-fs.target ignition-files.service initrd-setup-root.service
 Before=initrd-parse-etc.service
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 [Service]
 Type=oneshot

--- a/dracut/99setup-root/initrd-setup-root.service
+++ b/dracut/99setup-root/initrd-setup-root.service
@@ -4,6 +4,8 @@ DefaultDependencies=no
 RequiresMountsFor=/sysroot/usr/
 After=initrd-root-fs.target
 Before=initrd-parse-etc.service
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Depending on the timing, the failure of the setup-root service may cause a boot loop when the emergency target starts but the service continues to restart. This was seen with the coreos.update.badusr kola test. As with other important services in the initrd, make sure we start the emergency target in the isolate job mode which stops all other services.

## How to use

https://github.com/flatcar/scripts/pull/892 is quite good at provoking the bootloop, check if that patch here solves it.

## Testing done

Tested as part of https://github.com/flatcar/scripts/pull/892

