### PR TITLE
setup-root: Download sysext images if required

### DIFF
--- a/dracut/99setup-root/gpg-agent-wrapper
+++ b/dracut/99setup-root/gpg-agent-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/gpg-agent "$@"

--- a/dracut/99setup-root/initrd-setup-root-after-ignition
+++ b/dracut/99setup-root/initrd-setup-root-after-ignition
@@ -1,12 +1,70 @@
 #!/bin/bash
 set -euo pipefail
 
+function usrbin() {
+  local cmd="$1"
+  shift
+  LD_LIBRARY_PATH=/sysusr/usr/lib64 /sysusr/usr/bin/"${cmd}" "$@"
+}
+
+function usrcurl() {
+  usrbin curl -fsSL --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 "$@"
+}
+
+function download_and_verify() {
+  # Downloads release artifact to /sysroot/$name and verifies $name.sig with gpg
+  # Expects the env vars: FLATCAR_BOARD, VERSION
+  local name="$1"
+  local channel=""
+  case $(echo "${VERSION}" | cut -d . -f 2) in
+    0) channel="alpha" ;;
+    1) channel="beta" ;;
+    2) channel="stable" ;;
+    3) channel="lts" ;;
+    *) ;;
+  esac
+  local URLS=()
+  if [ "${channel}" != "" ]; then
+    URLS+=("https://${channel}.release.flatcar-linux.net/${FLATCAR_BOARD}/${VERSION}/${name}")
+  fi
+  URLS+=("https://bincache.flatcar-linux.net/images/${FLATCAR_BOARD/-usr}/${VERSION}/${name}")
+  local URL=""
+  for URL in "${URLS[@]}"; do
+    usrcurl -o "/sysroot/${name}" "${URL}" || { rm -f "/sysroot/${name}" ; continue ; }
+    usrcurl -o "/sysroot/${name}.sig" "${URL}.sig" || { rm -f "/sysroot/${name}.sig" ; continue ; }
+    break
+  done
+  if [ ! -e "/sysroot/${name}" ] || [ ! -e "/sysroot/${name}.sig" ]; then
+    echo "Failed to download required sysext image ${name}" >&2
+    exit 1 # Fail the boot
+  fi
+  local GPG_KEY=""
+  local GPG_LONG_ID=""
+  # Extract public key from flatcar-install
+  GPG_KEY=$(tr '\n' '_'  < /sysroot/usr/bin/flatcar-install | grep -Po 'GPG_KEY="\K.*?(?=")' | tr '_' '\n')
+  GPG_LONG_ID=$(grep -Po '^GPG_LONG_ID="\K.*?(?=")' /sysroot/usr/bin/flatcar-install)
+  export GNUPGHOME=/run/_gpg
+  mkdir -p "${GNUPGHOME}"
+  usrbin chmod 700 "${GNUPGHOME}"
+  usrbin gpg --batch --quiet --import <<< "${GPG_KEY}"
+  if ! usrbin gpg --batch --trusted-key "${GPG_LONG_ID}" --verify "/sysroot/${name}.sig" "/sysroot/${name}"; then
+    rm -f "/sysroot/${name}.sig" "/sysroot/${name}"
+    rm -rf "${GNUPGHOME}"
+    echo "Failed to verify required sysext image ${name}" >&2
+    exit 1 # Fail the boot
+  fi
+  rm "/sysroot/${name}.sig"
+  rm -rf "${GNUPGHOME}"
+  true # Don't leak previous exit code as return code
+}
+
 # Manage sysext symlinks to select the active sysext image, and do OEM partition migrations
 # (An alternative to symlinks is to implement support for ".v directories" in systemd-sysext
 # that could contain multiple versions and the right one gets selected, here not the newest
 # but that matching the OS version. However, we would still need the migration logic and
 # would not be able to use the OEM partition as dynamically preferred storage.)
-VERSION=$(grep -m 1 "^VERSION=" /sysroot/usr/lib/os-release | cut -d = -f 2)
+VERSION=$(source /sysroot/usr/lib/os-release ; echo "${VERSION}")
+FLATCAR_BOARD=$(source /sysroot/usr/lib/os-release ; echo "${FLATCAR_BOARD}")
 
 # Not all OEM partitions have an oem-release file but we require it now
 OEMID=$({ grep -m 1 -o "^ID=.*" /sysroot/oem/oem-release || true ; } | cut -d = -f 2)
@@ -49,9 +107,30 @@ if [ "${OEMID}" != "" ] && [ -e "/sysroot/oem/sysext/active-oem-${OEMID}" ]; the
     # when it's not needed (i.e., the active and new inactive both have a versioned sysext)
     ACTIVE_OEM="${INITIAL_MVP}"
   else
-    echo "Did not find ${SYSEXT_OEM_PART} nor ${SYSEXT_ROOT_PART}" >&2
-    # TODO: Try to download it as fallback (needs starting and waiting for the network target), or maybe just give up and place a warning somewhere (motd?)
-    # URL could be https://update.release.flatcar-linux.net/${FLATCAR_BOARD}/${VERSION}/oem-${OEMID}.raw.XY
+    echo "Did not find ${SYSEXT_OEM_PART} nor ${SYSEXT_ROOT_PART}, downloading" >&2
+    systemctl start --quiet systemd-networkd systemd-resolved
+    download_and_verify "oem-${OEMID}.raw"
+    mkdir -p /run/_oem
+    mount "/sysroot/oem-${OEMID}.raw" /run/_oem/
+    if grep -q SYSEXT_LEVEL=1.0 "/run/_oem/usr/lib/extension-release.d/extension-release.oem-${OEMID}" ; then
+      # The initial MVP OEM is only supported on the OEM partition
+      ACTIVE_OEM="${INITIAL_MVP}"
+    fi
+    umount "/sysroot/oem-${OEMID}.raw"
+    mkdir -p /sysroot/oem/sysext/
+    if [ "${ACTIVE_OEM}" != "" ]; then
+      mv "/sysroot/oem-${OEMID}.raw" "/sysroot/${ACTIVE_OEM}"
+    else
+      echo "Trying to place /sysroot/oem-${OEMID}.raw on OEM partition" >&2
+      if mv "/sysroot/oem-${OEMID}.raw" /sysroot/oem/sysext/; then
+        ACTIVE_OEM="${SYSEXT_OEM_PART}"
+      else
+        echo "That failed, moving it to right location on root partition" >&2
+        mkdir -p /sysroot/etc/flatcar/oem-sysext/
+        mv "/sysroot/oem-${OEMID}.raw" /sysroot/etc/flatcar/oem-sysext/
+        ACTIVE_OEM="${SYSEXT_ROOT_PART}"
+      fi
+    fi
   fi
   if [ "${ACTIVE_OEM}" != "" ] && [ -e "/sysroot/${ACTIVE_OEM}" ]; then
     mkdir -p "/sysroot/etc/extensions"
@@ -81,8 +160,8 @@ for NAME in $(grep -o '^[^#]*' /sysroot/etc/flatcar/enabled-sysext.conf || true)
   ACTIVE_EXT="/etc/flatcar/sysext/flatcar-${NAME}-${VERSION}.raw"
   if [ ! -e "/sysroot/${ACTIVE_EXT}" ]; then
     echo "Did not find ${ACTIVE_EXT}" >&2
-    # TODO: download it as fallback and if that fails, place a warning somewhere
-    # URL could be https://update.release.flatcar-linux.net/${FLATCAR_BOARD}/${VERSION}/flatcar-${NAME}.raw.XY
+    download_and_verify "flatcar-${NAME}.raw"
+    mv "/sysroot/flatcar-${NAME}.raw" "/sysroot/${ACTIVE_EXT}"
   fi
   if [ -e "/sysroot/${ACTIVE_EXT}" ]; then
     mkdir -p "/sysroot/etc/extensions"

--- a/dracut/99setup-root/module-setup.sh
+++ b/dracut/99setup-root/module-setup.sh
@@ -19,4 +19,6 @@ install() {
 
     inst_simple "${moddir}/initrd-setup-root-after-ignition.service" \
         "${systemdsystemunitdir}/initrd-setup-root-after-ignition.service"
+    inst_script "$moddir/gpg-agent-wrapper" \
+        "/usr/bin/gpg-agent"
 }


### PR DESCRIPTION
The sysext images required for the OEM or optional extensions should be downloaded if not found. For OEM sysext images they can be missing if the user deleted them or if the additional update payload didn't wasn't used (e.g., a custom Nebraska server or flatcar-update without the right OEM payload). For optional extensions it is expected that they get downloaded on-demand on first boot (like with the OEM sysext we also need a fallback)
Add download logic for OEM sysext images as fallback method. Also use the same download logic for optional extensions where they get downloaded on first-boot (or on reboot as fallback when the update tool didn't provide the right payload).


## How to use


## Testing done

see https://github.com/flatcar/scripts/pull/906