### PR TITLE
[app-crypt/clevis] Add clevis wrappers and preliminary support

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,14 @@
+{
+  "scanSettings": {
+    "baseBranches": []
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure",
+    "displayMode": "diff",
+    "useMendCheckNames": true
+  },
+  "issueSettings": {
+    "minSeverityLevel": "LOW",
+    "issueType": "DEPENDENCY"
+  }
+}

--- a/dracut/30ignition/clevis-decrypt-tpm2-wrapper
+++ b/dracut/30ignition/clevis-decrypt-tpm2-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/clevis-decrypt-tpm2 "$@"

--- a/dracut/30ignition/clevis-decrypt-wrapper
+++ b/dracut/30ignition/clevis-decrypt-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/clevis-decrypt "$@"

--- a/dracut/30ignition/clevis-encrypt-tpm2-wrapper
+++ b/dracut/30ignition/clevis-encrypt-tpm2-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/clevis-encrypt-tpm2 "$@"

--- a/dracut/30ignition/clevis-luks-askpass-wrapper
+++ b/dracut/30ignition/clevis-luks-askpass-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/local/libexec/clevis-luks-askpass "$@"

--- a/dracut/30ignition/clevis-luks-askpass.path
+++ b/dracut/30ignition/clevis-luks-askpass.path
@@ -1,0 +1,13 @@
+[Unit]
+Description=Forward Password Requests to Clevis Directory Watch
+Documentation=man:clevis-luks-unlockers(7)
+DefaultDependencies=no
+Before=cryptsetup-pre.target
+Wants=cryptsetup-pre.target
+
+[Path]
+DirectoryNotEmpty=/run/systemd/ask-password
+MakeDirectory=yes
+
+[Install]
+WantedBy=cryptsetup.target

--- a/dracut/30ignition/clevis-luks-askpass.service
+++ b/dracut/30ignition/clevis-luks-askpass.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Forward Password Requests to Clevis
+Documentation=man:clevis-luks-unlockers(7)
+DefaultDependencies=no
+
+[Service]
+Type=simple
+ExecStart=@libexecdir@/clevis-luks-askpass -l

--- a/dracut/30ignition/clevis-luks-bind-wrapper
+++ b/dracut/30ignition/clevis-luks-bind-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/clevis-luks-bind "$@"

--- a/dracut/30ignition/clevis-luks-common-functions-wrapper
+++ b/dracut/30ignition/clevis-luks-common-functions-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/clevis-luks-common-functions "$@"

--- a/dracut/30ignition/clevis-luks-list-wrapper
+++ b/dracut/30ignition/clevis-luks-list-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/clevis-luks-list "$@"

--- a/dracut/30ignition/clevis-luks-unlock-wrapper
+++ b/dracut/30ignition/clevis-luks-unlock-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/clevis-luks-unlock "$@"

--- a/dracut/30ignition/clevis-reply-password-wrapper
+++ b/dracut/30ignition/clevis-reply-password-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/lib/systemd-reply-password "$@"

--- a/dracut/30ignition/clevis-wrapper
+++ b/dracut/30ignition/clevis-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/clevis "$@"

--- a/dracut/30ignition/jose-wrapper
+++ b/dracut/30ignition/jose-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/jose "$@"

--- a/dracut/30ignition/luksmeta-wrapper
+++ b/dracut/30ignition/luksmeta-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/luksmeta "$@"

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -59,6 +59,15 @@ install() {
         pwmake \
         tpm2_create
 
+
+
+ inst_simple "$moddir/clevis-luks-askpass.service" "$systemdsystemunitdir/clevis-luks-askpass.service"
+ inst_simple "$moddir/clevis-luks-askpass.path" "$systemdsystemunitdir/clevis-luks-askpass.path"
+
+   systemctl -q --root "$initdir" add-wants cryptsetup.target clevis-luks-askpass.path
+
+
+
     # Required by s390x's z/VM installation.
     # Supporting https://github.com/coreos/ignition/pull/865
     inst_multiple -o chccwdev vmur
@@ -132,4 +141,47 @@ install() {
         "/usr/bin/ignition"
     inst_script "$moddir/setfiles-wrapper" \
         "/usr/bin/setfiles"
+    inst_script "$moddir/clevis-decrypt-tpm2-wrapper" \
+        "/usr/bin/clevis-decrypt-tpm2"
+    inst_script "$moddir/clevis-decrypt-wrapper" \
+        "/usr/bin/clevis-decrypt"
+    inst_script "$moddir/clevis-encrypt-tpm2-wrapper" \
+        "/usr/bin/clevis-encrypt-tpm2"
+    inst_script "$moddir/clevis-luks-askpass-wrapper" \
+        "/usr/bin/clevis-luks-askpass"
+    inst_script "$moddir/clevis-luks-bind-wrapper" \
+        "/usr/bin/clevis-luks-bind"
+    inst_script "$moddir/clevis-luks-common-functions-wrapper" \
+        "/usr/bin/clevis-luks-common-functions"
+    inst_script "$moddir/clevis-luks-list-wrapper" \
+        "/usr/bin/clevis-luks-list"
+    inst_script "$moddir/clevis-luks-unlock-wrapper" \
+        "/usr/bin/clevis-luks-unlock"
+    inst_script "$moddir/clevis-reply-password-wrapper" \
+        "/usr/bin/clevis-reply-password"
+    inst_script "$moddir/clevis-wrapper" \
+        "/usr/bin/clevis"
+    inst_script "$moddir/jose-wrapper" \
+        "/usr/bin/jose"
+    inst_script "$moddir/luksmeta-wrapper" \
+        "/usr/bin/luksmeta"
+    inst_script "$moddir/setfiles-wrapper" \
+        "/usr/bin/setfiles"
+    inst_script "$moddir/tpm2_createprimary-wrapper" \
+        "/usr/bin/tpm2_createprimary"
+    inst_script "$moddir/tpm2_flushcontext-wrapper" \
+        "/usr/bin/tpm2_flushcontext"
+    inst_script "$moddir/tpm2_load-wrapper" \
+        "/usr/bin/tpm2_load"
+    inst_script "$moddir/tpm2_pcrlist-wrapper" \
+        "/usr/bin/tpm2_pcrlist"
+    inst_script "$moddir/tpm2_pcrread-wrapper" \
+        "/usr/bin/tpm2_pcrread"
+    inst_script "$moddir/tpm2_unseal-wrapper" \
+        "/usr/bin/tpm2_unseal"
+
+
+
+
+
 }

--- a/dracut/30ignition/pwmake-wrapper
+++ b/dracut/30ignition/pwmake-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/pwmake "$@"

--- a/dracut/30ignition/test.sh
+++ b/dracut/30ignition/test.sh
@@ -1,0 +1,9 @@
+for i in clevis-encrypt-tpm2 clevis-luks-bind clevis-luks-common-functions clevis-luks-unlock  pwmake tpm2_create clevis-decrypt-tpm2 tpm2_createprimary tpm2_flushcontext tpm2_load tpm2_unseal tpm2_pcrread tpm2_pcrlist clevis-luks-common-functions clevis-decrypt clevis-luks-list luksmeta clevis jose; do printf "#!/bin/sh\nLD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/"$i" "$@"\n" > "$i"-wrapper; done
+
+printf   "#!/bin/sh\nLD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/local/libexec/clevis-luks-askpass "$@"\n"   > clevis-luks-askpass-wrapper  
+printf   "#!/bin/sh\nLD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/lib/systemd-reply-password "$@"\n"   > clevis-reply-password-wrapper
+
+
+
+
+

--- a/dracut/30ignition/tpm2_create-wrapper
+++ b/dracut/30ignition/tpm2_create-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/tpm2_create "$@"

--- a/dracut/30ignition/tpm2_createprimary-wrapper
+++ b/dracut/30ignition/tpm2_createprimary-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/tpm2_createprimary "$@"

--- a/dracut/30ignition/tpm2_flushcontext-wrapper
+++ b/dracut/30ignition/tpm2_flushcontext-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/tpm2_flushcontext "$@"

--- a/dracut/30ignition/tpm2_load-wrapper
+++ b/dracut/30ignition/tpm2_load-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/tpm2_load "$@"

--- a/dracut/30ignition/tpm2_pcrlist-wrapper
+++ b/dracut/30ignition/tpm2_pcrlist-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/tpm2_pcrlist "$@"

--- a/dracut/30ignition/tpm2_pcrread-wrapper
+++ b/dracut/30ignition/tpm2_pcrread-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/tpm2_pcrread "$@"

--- a/dracut/30ignition/tpm2_unseal-wrapper
+++ b/dracut/30ignition/tpm2_unseal-wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec /sysusr/usr/bin/tpm2_unseal "$@"

--- a/dracut/99setup-root/initrd-setup-root-after-ignition.service
+++ b/dracut/99setup-root/initrd-setup-root-after-ignition.service
@@ -4,6 +4,8 @@ DefaultDependencies=no
 RequiresMountsFor=/sysroot/usr/ /sysroot/oem/
 After=initrd-root-fs.target ignition-files.service initrd-setup-root.service
 Before=initrd-parse-etc.service
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 [Service]
 Type=oneshot

--- a/dracut/99setup-root/initrd-setup-root.service
+++ b/dracut/99setup-root/initrd-setup-root.service
@@ -4,6 +4,8 @@ DefaultDependencies=no
 RequiresMountsFor=/sysroot/usr/
 After=initrd-root-fs.target
 Before=initrd-parse-etc.service
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
# [app-crypt/clevis] Add clevis wrappers and preliminary support

Most of the support has already been added. Rest is to be done. I opened a pull request so the team can benefit from my existing work.

## Testing done

Built bootengine and subsequently the kernel successfully with the wrappers available from the initramfs.

