### PR TITLE
dracut: depend on net-lib module

### DIFF
--- a/dracut/03flatcar-network/module-setup.sh
+++ b/dracut/03flatcar-network/module-setup.sh
@@ -5,7 +5,7 @@
 
 # called by dracut
 depends() {
-    echo systemd-networkd
+    echo net-lib systemd-networkd
 }
 
 # called by dracut
@@ -41,10 +41,6 @@ install() {
 
     inst_simple "$moddir/zz-default.network" \
         "$systemdutildir/network/zz-default.network"
-
-    # install net-lib.sh regardless of its parent module's status
-    inst_simple "$moddir/../40network/net-lib.sh" /lib/net-lib.sh ||
-    dfatal 'Could not install net-lib.sh from the network module'
 
     # add a hook to generate networkd configuration from ip= arguments
     inst_hook cmdline 99 "$moddir/parse-ip-for-networkd.sh"


### PR DESCRIPTION
# [Discuss dracut upstream change]

Somewhat abusing the PR process a bit I wanted to reach out from the dracut upstream team to get feedback on an upstream PR that we hope would benefit this project as well. 

Upstream dracut is considering to introduce a new dracut module called net-lib that would manage installing net-lib.sh (so that bootengine does not need to do that "manually) 

https://github.com/dracutdevs/dracut/pull/2250

If upstream lands, that would be only be release around Dec this year or later, so plenty of time to coordinate this work.

Please feel free to comment directly on the upstream bug (and if desired close this PR)