### PR TITLE
network: Ignore mana VFs on Azure

### DIFF
--- a/dracut/03flatcar-network/yy-azure-sriov-coreos.network
+++ b/dracut/03flatcar-network/yy-azure-sriov-coreos.network
@@ -9,7 +9,7 @@ KernelCommandLine=coreos.oem.id=azure
 # VF driver currently used in Azure. If other drivers come into use, the
 # symptom will be a VF interface in the output of "networkctl" which never
 # finishes configuring.
-Driver=mlx4_en mlx5_core
+Driver=mlx4_en mlx5_core mana
 
 [Link]
 Unmanaged=yes

--- a/dracut/03flatcar-network/yy-azure-sriov.network
+++ b/dracut/03flatcar-network/yy-azure-sriov.network
@@ -9,7 +9,7 @@ KernelCommandLine=flatcar.oem.id=azure
 # VF driver currently used in Azure. If other drivers come into use, the
 # symptom will be a VF interface in the output of "networkctl" which never
 # finishes configuring.
-Driver=mlx4_en mlx5_core
+Driver=mlx4_en mlx5_core mana
 
 [Link]
 Unmanaged=yes


### PR DESCRIPTION
Azure is introducing a new generation of NICs, that are architected the same way as the current Mellanox based ones: there is a synthetic (vmbus) NIC for handling some control traffic (including DHCP) and a VF that is enslaved to the synthetic NIC. We therefore need to exclude the devices managed by the mana driver from IP management.