### PR TITLE
ignition: Add partprobe to initrd

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -37,6 +37,7 @@ install() {
         mkswap \
         nvme \
         sgdisk \
+        partprobe \
         useradd \
         userdel \
         usermod \


### PR DESCRIPTION
The sgdisk tool does not update the kernel partition table in contrast to other similar tools. Often udev can detect the changes but not always as experienced when adding a new partition on Flatcar's boot disk. Instead of implicitly relying on some other component to re-read the kernel partition table, trigger the re-read with partprobe. This is proposed in https://github.com/coreos/ignition/pull/1717


## How to use


## Testing done

Done in https://github.com/flatcar/scripts/pull/1202

