### PR TITLE
network: Disable RoutesToDNS

### DIFF
--- a/dracut/03flatcar-network/zz-default.network
+++ b/dracut/03flatcar-network/zz-default.network
@@ -9,3 +9,6 @@ IPv6AcceptRA=true
 [DHCP]
 UseMTU=true
 UseDomains=true
+
+[DHCPv4]
+RoutesToDNS=false


### PR DESCRIPTION
# network: Disable RoutesToDNS

Flatcar VMs on Azure with multiple nics fail to provision correctly because of multiple routes to wireserver (168.63.129.16) with the same metric, and wireserver only responds to 'ready' signals on the primary nic. The primary nic gets an explicit route to wireserver through dhcp. It turns out systemd is adding the extra routes because wireserver is also the dhcp and dns server, and the default RoutesToDNS=true setting is the reason.

This behavior is non-standard and I don't think it's expected on any platform. Disable this behavior by default.

## How to use

`az vm create --nics ...`

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
