### PR TITLE
initrd-setup-root-after-ignition: Clean up incomplete move target

### DIFF
--- a/dracut/99setup-root/initrd-setup-root-after-ignition
+++ b/dracut/99setup-root/initrd-setup-root-after-ignition
@@ -77,6 +77,7 @@ if [ "${OEMID}" != "" ] && [ -e "/sysroot/oem/sysext/active-oem-${OEMID}" ]; the
     if mv "/sysroot/${SYSEXT_ROOT_PART}" /sysroot/oem/sysext/; then
       ACTIVE_OEM="${SYSEXT_OEM_PART}"
     else
+      rm -f "/sysroot${SYSEXT_OEM_PART}"
       echo "That failed, keeping it on root partition" >&2
       ACTIVE_OEM="${SYSEXT_ROOT_PART}"
     fi
@@ -89,6 +90,7 @@ if [ "${OEMID}" != "" ] && [ -e "/sysroot/oem/sysext/active-oem-${OEMID}" ]; the
     if mv "/sysroot/oem-${OEMID}.raw" "/sysroot${SYSEXT_OEM_PART}"; then
       ACTIVE_OEM="${SYSEXT_OEM_PART}"
     else
+      rm -f "/sysroot${SYSEXT_OEM_PART}"
       echo "That failed, moving it to right location on root partition" >&2
       mkdir -p /sysroot/etc/flatcar/oem-sysext/
       mv "/sysroot/oem-${OEMID}.raw" "/sysroot${SYSEXT_ROOT_PART}"


### PR DESCRIPTION
When possible we prefer to have the active OEM systemd-sysext live on the OEM partition to support cleaning up the rootfs without bricking the instance. However, "mv" doesn't clean up the incomplete target file which would fill the OEM disk, and that could cause future problems. Clean up the incomplete move target that filled the OEM disk when trying to store the active OEM sysext image there.

## How to use

Backport to Alpha/Beta because it is a potential bug fix.

## Testing done

in https://github.com/flatcar/scripts/pull/1272
