### PR TITLE
initrd-setup-root-after-ignition: Ensure /etc/extensions is mergable

### DIFF
--- a/dracut/99setup-root/initrd-setup-root-after-ignition
+++ b/dracut/99setup-root/initrd-setup-root-after-ignition
@@ -143,3 +143,16 @@ for NAME in $(grep -h -o '^[^#]*' /sysroot/etc/flatcar/enabled-sysext.conf /sysr
     rm -f "/sysroot/etc/extensions/flatcar-${NAME}.raw"
   fi
 done
+
+# The above mkdir runs when the /etc overlay is already set up and since overlayfs
+# creates any folders that don't exist in the lowerdir as opaque it means that when
+# they appear later in the lowerdir through an update, the lowerdir folder is ignored.
+# That happened in Beta when /etc/extensions wasn't present in /usr/share/flatcar/etc/.
+# Remove any opaque markers for directories created on boot. We don't create /etc/cni
+# here but it was also created later in boot and as a common folder it might be better
+# to have it non-opaque.
+for DIR in /sysroot/etc/extensions /sysroot/etc/flatcar /sysroot/etc/cni; do
+  if [ -d "${DIR}" ]; then
+    usrbin unshare -m sh -c "umount /sysroot/etc && /sysusr/usr/bin/attr -R -r overlay.opaque '${DIR}' || true"
+  fi
+done


### PR DESCRIPTION
In Beta 3760.1.0 the /etc/extensions/ folder gets created by "mkdir -p" because it does not exist in the lowerdir /usr/share/flatcar/etc/. This causes the opaque marker to be set by overlayfs. The update to Alpha thus does not merge the new /usr/share/flatcar/etc/extensions/ folder with its docker/containerd sysext symlinks. We should have had /etc/extensions/ in the lowerdir in Beta but didn't.

Ensure that the created folders are mergable by removing the overlayfs marker. This is needed for existing installations and folders we expect to exist in the lowerdir but might be missing for whatever reason.

## How to use

Backport to Alpha and Beta

## Testing done

TODO

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
