### PR TITLE
initrd-setup-root: Clean up whiteout entries for files to be recreated

### DIFF
--- a/dracut/99setup-root/initrd-setup-root
+++ b/dracut/99setup-root/initrd-setup-root
@@ -66,6 +66,17 @@ if [ -s /sysroot/selective-os-reset ]; then
   rm -f /sysroot/etc/machine-id
 fi
 
+# Remove any user-created whiteouts for files that have a tmpfiles
+# rule which normally would recreate them (we use the lowerdir for that).
+while IFS="" read -r entry ; do
+  entry="/sysroot${entry}"
+  # The -c check for character devs also guards against empty strings and nonexisting files
+  # The stat command prints the major and minor device type in decimal
+  if [ -c "${entry}" ] && [ "$(stat --printf='%Hr %Lr\n' "${entry}")" = "0 0" ]; then
+    rm "${entry}" || true
+  fi
+done < /sysroot/usr/share/flatcar/etc-no-whiteouts
+
 # This creates the modifiable users/groups in /sysroot/etc,
 # initializing the shadow database in the process. This needs to
 # happen early, so systemd-tmpfiles can read the user info from


### PR DESCRIPTION
The removal of files in the overlay present in the lowerdir creates whiteout entries that mask the lowerdir entries. For those files that have a tmpfile rule for creation, a reboot would cause the file to be created in the upperdir, meaning this file is not updated from the lowerdir when it changes. In addition we have filtered out some tmpfile rules that caused upcopies (symlinks and directories) which meant that removing the /etc/resolv.conf symlink didn't bring it back after reboot. To make files from the lowerdir show up if they have a tmpfile rule that normally would recreate them we keep a list of whiteout entries that we clean up on boot. This also prevents freezing files because systemd-tmpfiles does not need to recreate them in the upperdir.

## How to use

Backport to Stable

## Testing done

Removal of `/etc/resolv.conf` and reboot brings it back.

Note that not all files have a tmpfiles rule, e.g., `sshd_config` has not. We could identify files like that which need to exist for a working system by running `rm -rf /etc/*` and rebooting.
This is different from the removal of `/etc` contents after `umount /etc` which works without a problem and brings all files back.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
