### PR TITLE
ignition: Remove partprobe dependency and use partx

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -37,7 +37,7 @@ install() {
         mkswap \
         nvme \
         sgdisk \
-        partprobe \
+        partx \
         useradd \
         userdel \
         usermod \


### PR DESCRIPTION
Partx is already present, but not explicitly mentioned. We can use it instead of partprobe which is not needed anymore after upstreaming our Ignition patch (https://github.com/flatcar/scripts/pull/1403).

## How to use

With new PR in https://github.com/flatcar/scripts/pull/3161

## Testing done


- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
