### PR TITLE
update-bootengine: Install mmc_block module in initrd

### DIFF
--- a/update-bootengine
+++ b/update-bootengine
@@ -34,7 +34,7 @@ DRACUT_ARGS=(
     --omit multipath
     --omit network
     --add iscsi
-    --add-drivers "loop brd drbd nbd rbd xen-blkfront zram libarc4 lru_cache zsmalloc"
+    --add-drivers "loop brd drbd nbd rbd mmc_block xen-blkfront zram libarc4 lru_cache zsmalloc"
     )
 
 SETUP_MOUNTS=


### PR DESCRIPTION
The mmc_block module used to be present in the initrd but got lost in the Linux 6.1 update.
Add it back explicitly.

## How to use

Backport to Beta/Alpha

## Testing done

modprobe in the initrd now works again

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
