### PR TITLE
ignition-setup: Keep looking at old place for PXE OEM initrd contents

### DIFF
--- a/dracut/30ignition/ignition-setup.sh
+++ b/dracut/30ignition/ignition-setup.sh
@@ -15,8 +15,11 @@ normal)
     printf '#!/bin/sh\nexit 1\n' > /bin/is-live-image
     ;;
 pxe)
-    # OEM directory in the initramfs itself
-    src=/oem
+    # OEM directory in the initramfs itself.
+    # Despite having the OEM partition being moved to
+    # /oem in general, we keep checking /usr/share/oem in initrds to avoid
+    # breaking compatibility.
+    src=/usr/share/oem
     # Workaround, "chmod" is not available
     cp -a /bin/cat /bin/is-live-image
     printf '#!/bin/sh\nexit 0\n' > /bin/is-live-image


### PR DESCRIPTION
The PXE OEM contents get supplied by a custom initrd the user sets up. This always used /usr/share/oem for the custom contents and we should stick to that instead of looking at /oem.
Revert the breaking change (it was not documented, hence I don't think someone picked this up).


## How to use


## Testing done

