### PR TITLE
initrd-setup-root-after-ignition: Ensure /etc/flatcar/sysext exists

### DIFF
--- a/dracut/99setup-root/initrd-setup-root-after-ignition
+++ b/dracut/99setup-root/initrd-setup-root-after-ignition
@@ -134,6 +134,10 @@ for NAME in $(grep -h -o '^[^#]*' /sysroot/etc/flatcar/enabled-sysext.conf /sysr
     echo "Did not find ${ACTIVE_EXT}" >&2
     systemctl start --quiet systemd-networkd systemd-resolved
     download_and_verify "flatcar-${NAME}.raw"
+    # Note: This folder is created opaque since it does not exist in the underlay
+    # For cases where we ship it later, it's best to add a "attr" call in flatcar-postinst
+    # because there are many ways how the folder might have been created
+    mkdir -p "/sysroot/etc/flatcar/sysext/"
     mv "/sysroot/flatcar-${NAME}.raw" "/sysroot/${ACTIVE_EXT}"
   fi
   if [ -e "/sysroot/${ACTIVE_EXT}" ]; then

--- a/update-bootengine
+++ b/update-bootengine
@@ -112,6 +112,8 @@ export DRACUT_NO_XATTR
 
 mkdir -p "${USE_CHROOT}$(dirname "$CPIO_PATH")"
 if [[ -n "$USE_CHROOT" ]]; then
+    # ROOT interferes with some utilities after chroot (gcc-config).
+    unset ROOT
     echo "Running dracut in $USE_CHROOT"
     LC_ALL=C chroot "$USE_CHROOT" ldconfig -X
     LC_ALL=C chroot "$USE_CHROOT" dracut "${DRACUT_ARGS[@]}" "$CPIO_PATH"

--- a/update-bootengine
+++ b/update-bootengine
@@ -33,6 +33,7 @@ DRACUT_ARGS=(
     --omit lvm
     --omit multipath
     --omit network
+    --omit zfs
     --add iscsi
     --add-drivers "loop brd drbd nbd rbd mmc_block xen-blkfront zram libarc4 lru_cache zsmalloc"
     )


### PR DESCRIPTION
Nothing guarantees that this folder is created, so we need to mkdir it before moving the sysext into it. Otherwise the user is forced to create it with ignition when specifying sysexts to install in
/etc/flatcar/enabled-sysext.conf.
