### PR TITLE
Draft for Proxmox support

### DIFF
--- a/dracut/30ignition/flatcar-afterburn-network.service
+++ b/dracut/30ignition/flatcar-afterburn-network.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Flatcar DigitalOcean Network Agent
+Description=Flatcar Afterburn network service
 DefaultDependencies=false
 Before=initrd.target
 After=systemd-networkd.service initrd-root-fs.target

--- a/dracut/30ignition/flatcar-metadata-hostname.service
+++ b/dracut/30ignition/flatcar-metadata-hostname.service
@@ -33,8 +33,10 @@ ConditionKernelCommandLine=|flatcar.oem.id=vultr
 # Addition:
 ConditionKernelCommandLine=|coreos.oem.id=packet
 ConditionKernelCommandLine=|flatcar.oem.id=packet
+
 ConditionKernelCommandLine=|flatcar.oem.id=hetzner
 ConditionKernelCommandLine=|flatcar.oem.id=kubevirt
+ConditionKernelCommandLine=|flatcar.oem.id=proxmoxve
 
 OnFailure=emergency.target
 OnFailureJobMode=isolate

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -146,6 +146,6 @@ if [ "${nopxe}" = 1 ]; then
     add_requires "disk-uuid.service" initrd.target
 fi
 
-if [[ $(cmdline_arg flatcar.oem.id) == "digitalocean" ]] || [[ $(cmdline_arg coreos.oem.id) == "digitalocean" ]]; then
+if [[ $(cmdline_arg flatcar.oem.id) == "digitalocean" ]] || [[ $(cmdline_arg coreos.oem.id) == "digitalocean" ]] || [[ $(cmdline_arg flatcar.oem.id) == "proxmoxve" ]]; then
     add_requires flatcar-digitalocean-network.service initrd.target
 fi

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -147,5 +147,5 @@ if [ "${nopxe}" = 1 ]; then
 fi
 
 if [[ $(cmdline_arg flatcar.oem.id) == "digitalocean" ]] || [[ $(cmdline_arg coreos.oem.id) == "digitalocean" ]] || [[ $(cmdline_arg flatcar.oem.id) == "proxmoxve" ]]; then
-    add_requires flatcar-digitalocean-network.service initrd.target
+    add_requires flatcar-afterburn-network.service initrd.target
 fi

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -99,14 +99,14 @@ install() {
     done
 
     # Flatcar: add ignition-quench.service, sysroot-boot.service,
-    # flatcar-digitalocean-network.service, flatcar-static-network.service,
+    # flatcar-afterburn-network.service, flatcar-static-network.service,
     # flatcar-metadata-hostname.service, flatcar-openstack-hostname.service
     inst_simple "$moddir/ignition-quench.service" \
         "$systemdsystemunitdir/ignition-quench.service"
     inst_simple "$moddir/sysroot-boot.service" \
         "$systemdsystemunitdir/sysroot-boot.service"
-    inst_simple "$moddir/flatcar-digitalocean-network.service" \
-        "$systemdsystemunitdir/flatcar-digitalocean-network.service"
+    inst_simple "$moddir/flatcar-afterburn-network.service" \
+        "$systemdsystemunitdir/flatcar-afterburn-network.service"
     inst_simple "$moddir/flatcar-static-network.service" \
         "$systemdsystemunitdir/flatcar-static-network.service"
     inst_simple "$moddir/flatcar-metadata-hostname.service" \


### PR DESCRIPTION
This makes use of https://github.com/coreos/afterburn/pull/1023 to set up any static networking from the initrd (for Ignition) and the hostname (early enough so that Ignition could overwrite it).

## Testing done

Tested with Flatcar community: https://github.com/flatcar/Flatcar/discussions/1573#discussioncomment-11170022
