### PR TITLE
ignition: fixes hyperv oem support

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -184,3 +184,9 @@ EOF
     done
 
 }
+
+# See: https://github.com/coreos/ignition/commit/d304850c3d3696822bc05e0833ee4b27df9d7a38
+installkernel() {
+     # required by hyperv platform to read kvp from the kernel
+     instmods -c hv_utils
+}


### PR DESCRIPTION
Upstream Hyper-V  ignition support requires `hv_utils` module.

See: https://github.com/coreos/ignition/commit/d304850c3d3696822bc05e0833ee4b27df9d7a38

Ignition initrd is failing here: https://github.com/coreos/ignition/blob/v2.18.0/internal/providers/hyperv/kvp.go#L50.
Flatcar kernel is built with hv_utils kernel module, but the module is not present in initrd  /lib/modules because it has not been installed.

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
