### PR TITLE
dracut: Install libcryptsetup-token-systemd-tpm2 plugin

### DIFF
--- a/dracut/31decrypt-root/module-setup.sh
+++ b/dracut/31decrypt-root/module-setup.sh
@@ -4,6 +4,8 @@ install() {
 
     inst_simple "$moddir/decrypt-root.service" \
         "$systemdsystemunitdir/decrypt-root.service"
-    
+
+    inst_simple /usr/lib64/cryptsetup/libcryptsetup-token-systemd-tpm2.so
+
     systemctl --root "$initdir" enable decrypt-root.service
 }


### PR DESCRIPTION
For unlocking TPM2-backed LUKS volumes that were set up with systemd-cryptenroll we need the plugin library in the initrd.


## How to use/Testing done

This now works with:

```
variant: flatcar
version: 1.1.0
storage:
  luks:
  - name: rootencrypted
    wipe_volume: true
    device: "/dev/disk/by-partlabel/ROOT"
  filesystems:
    - device: /dev/mapper/rootencrypted
      format: ext4
      label: ROOT
systemd:
  units:
    - name: cryptenroll-helper.service
      enabled: true
      contents: |
        [Unit]
        ConditionFirstBoot=true
        OnFailure=emergency.target
        OnFailureJobMode=isolate
        [Service]
        Type=oneshot
        RemainAfterExit=yes
        ExecStart=systemd-cryptenroll --tpm2-device=auto --unlock-key-file=/etc/luks/rootencrypted --wipe-slot=0 /dev/disk/by-partlabel/ROOT
        ExecStart=rm /etc/luks/rootencrypted
        [Install]
        WantedBy=multi-user.target
```

By default PCR 7 is used, this can be disabled with `--tpm2-pcrs=""`. The effect of PCR 7 binding is that unlocking would fail when switching from BIOS to UEFI or doing similar firmware changes.