### PR TITLE
afterburn: set hostname for hetzner OEM

### DIFF
--- a/dracut/30ignition/flatcar-metadata-hostname.service
+++ b/dracut/30ignition/flatcar-metadata-hostname.service
@@ -33,6 +33,7 @@ ConditionKernelCommandLine=|flatcar.oem.id=vultr
 # Addition:
 ConditionKernelCommandLine=|coreos.oem.id=packet
 ConditionKernelCommandLine=|flatcar.oem.id=packet
+ConditionKernelCommandLine=|flatcar.oem.id=hetzner
 
 OnFailure=emergency.target
 OnFailureJobMode=isolate


### PR DESCRIPTION
# Use Hostname from metadata service for Hetzner OEM

Enables the existing afterburn service `flatcar-metadata-hostname.service` for the Hetzner OEM. This will read the hostname of the server from the Hetzner Cloud metadata service in the init process, and configure the server to use this hostname.

## How to use

Changes are pulled into `flatcar/scripts` in https://github.com/flatcar/scripts/pull/1880. This also explains how to use/test them.

## Testing done

I have referenced this commit in `flatcar/scripts` overlay and built a test image. A server created from this image used the correct hostname.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
