### PR TITLE
afterburn: set hostname for kubevirt OEM

### DIFF
--- a/dracut/30ignition/flatcar-metadata-hostname.service
+++ b/dracut/30ignition/flatcar-metadata-hostname.service
@@ -34,6 +34,7 @@ ConditionKernelCommandLine=|flatcar.oem.id=vultr
 ConditionKernelCommandLine=|coreos.oem.id=packet
 ConditionKernelCommandLine=|flatcar.oem.id=packet
 ConditionKernelCommandLine=|flatcar.oem.id=hetzner
+ConditionKernelCommandLine=|flatcar.oem.id=kubevirt
 
 OnFailure=emergency.target
 OnFailureJobMode=isolate


### PR DESCRIPTION
With Kubevirt OEM, the hostname can be set from the configdrive in OpenStack format (config-2 labelled) disk drive.