### PR TITLE
OpenStack: Use config-drive by default and metadata API as fallback

### DIFF
--- a/dracut/30ignition/flatcar-openstack-hostname.service
+++ b/dracut/30ignition/flatcar-openstack-hostname.service
@@ -14,4 +14,4 @@ Before=ignition-files.service
 [Service]
 Type=oneshot
 # Special case: the oem_id openstack does not match the afterburn name openstack-metadata
-ExecStart=/usr/bin/coreos-metadata --provider openstack-metadata --hostname=/sysroot/etc/hostname
+ExecStart=/usr/bin/coreos-metadata --provider openstack --hostname=/sysroot/etc/hostname


### PR DESCRIPTION
openstack: use config-drive by default and metadata API as fallback
Related: https://github.com/coreos/afterburn/pull/462

# OpenStack: Use config-drive by default and metadata API as fallback

Use afterburn `openstack` provider implemented on https://github.com/coreos/afterburn/pull/462 to use config-drive first and metadata API as a fallback mechanism.
Solves https://github.com/flatcar/Flatcar/issues/1445

## How to use

Build OpenStack image based on https://github.com/flatcar/scripts/pull/2009 to validate it does not bring regression on OpenStack platform.

## Testing done

To be performed on https://github.com/flatcar/scripts/pull/2009.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
