### PR TITLE
dracut: Insert dm_verity kernel module for veritysetup

### DIFF
--- a/dracut/10verity-generator/module-setup.sh
+++ b/dracut/10verity-generator/module-setup.sh
@@ -18,3 +18,8 @@ install() {
     inst_simple "$moddir/no-job-timeout.conf" \
         "$systemdsystemunitdir/dev-mapper-usr.device.d/no-job-timeout.conf"
 }
+
+installkernel() {
+    # required by cryptsetup, it seems like it stopped being implicitly inserted
+    instmods -c dm_verity
+}

--- a/dracut/10verity-generator/verity-generator
+++ b/dracut/10verity-generator/verity-generator
@@ -74,6 +74,9 @@ if [[ -n "${usr}" && -n "${usrhash}" ]]; then
 	[Service]
 	Type=oneshot
 	RemainAfterExit=yes
+	# Explicitly load dm_verity module - for some reason it stopped being
+	# loaded earlier in the boot, and cryptsetup needs it.
+	ExecStart=/bin/modprobe dm_verity
 	# Try to query the filesystem size dynamically but otherwise fall back to the expected value from the image GPT layout
 	ExecStart=/bin/sh -c '/sbin/veritysetup --panic-on-corruption --hash-offset="\$(e2size ${usr} || echo 1065345024)" open "${usr}" usr "${usr}" "${usrhash}"'
 	# If there's a hash mismatch during table initialization,


### PR DESCRIPTION
For some reason it stopped being inserted.

Tested as a part of https://github.com/flatcar/scripts/pull/1982
