### PR TITLE
ignition: keep network around when umounting

### DIFF
--- a/dracut/30ignition/ignition-mount.service
+++ b/dracut/30ignition/ignition-mount.service
@@ -13,7 +13,13 @@ After=ignition-disks.service
 Before=ignition-files.service
 
 # Make sure ExecStop= runs before we switch root
+# and that we order ourselves after network such that
+# if networking is brought up it will still be available
+# for our ExecStop= command. On some providers like Equinix
+# Metal (Packet) there is a network callback sent out
+# for each Ignition stage (including umount).
 Before=initrd-switch-root.target
+After=network.target
 
 OnFailure=emergency.target
 OnFailureJobMode=isolate


### PR DESCRIPTION
This keeps network in the umounting Ignition stage as Equinix Metal needs to POST a status update to Equinix Metal timeline at each stage.

This solves: https://github.com/flatcar/Flatcar/issues/1536

## Testing done

* Tested on Flatcar CI here: https://github.com/flatcar/scripts/pull/2308
* Upstream PR: https://github.com/coreos/ignition/pull/1940