### PR TITLE
ignition: systemd: fix systemd 256 usage

### DIFF
--- a/dracut/30ignition/ignition-setup.sh
+++ b/dracut/30ignition/ignition-setup.sh
@@ -3,6 +3,11 @@
 
 set -e
 
+# remount read write for Ignition required steps
+mount -o remount,rw /usr
+# remount read only after Ignition required steps finalized
+trap 'mount -o remount,ro /usr' EXIT
+
 case "$1" in
 normal)
     src=/mnt/oem


### PR DESCRIPTION
Systemd 256 mounts /usr as read-only, but Ignition setup requires to have some files written depending on the live image or the ignition contents.

The are multiple options we can consider:

  * this option, where we make /usr read-write and do the necessary changes
  * another option would be to setup symlinks which redirect to /tmp or a writable file we can write
  * another option would be to have the ignition binaries pre-baked by build_image
 
## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
