### PR TITLE
ignition: Fix PXE by using mount namespace rather than remounting RO

### DIFF
--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -137,6 +137,7 @@ OnFailureJobMode=isolate
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+MountFlags=slave
 ExecStart=/usr/sbin/ignition-setup ${nopxe:+normal} ${pxe:+pxe}
 EOF
 

--- a/dracut/30ignition/ignition-setup.sh
+++ b/dracut/30ignition/ignition-setup.sh
@@ -5,16 +5,14 @@ set -e
 
 # remount read write for Ignition required steps
 mount -o remount,rw /usr
-# remount read only after Ignition required steps finalized
-trap 'mount -o remount,ro /usr' EXIT
+# we run with MountFlags=slave, so the rw remount is not propagated outside the
+# unit - no need to remount ro or umount the OEM partition
 
 case "$1" in
 normal)
     src=/mnt/oem
     mkdir -p "${src}"
     mount /dev/disk/by-label/OEM "${src}"
-    # retry-umount may not be necessary, but be cautious
-    trap 'retry-umount "${src}"' EXIT
     # Workaround, "chmod" is not available
     cp -a /bin/cat /bin/is-live-image
     printf '#!/bin/sh\nexit 1\n' > /bin/is-live-image


### PR DESCRIPTION
Remounting read-only was failing due to systemd v256 holding a read-write file descriptor on systemd-executor. We don't need to do this inside a namespace. We don't need to unmount the OEM partition either.

[Jenkins](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/5478/cldsv/) is all green. I included Equinix Metal on amd64 and arm64.