### PR TITLE
Miscellaneous changes needed to use newer Dracut with its sysroot feature

### DIFF
--- a/dracut/03flatcar-network/module-setup.sh
+++ b/dracut/03flatcar-network/module-setup.sh
@@ -5,7 +5,7 @@
 
 # called by dracut
 depends() {
-    echo systemd-networkd
+    echo net-lib systemd-networkd
 }
 
 # called by dracut
@@ -41,10 +41,6 @@ install() {
 
     inst_simple "$moddir/zz-default.network" \
         "$systemdutildir/network/zz-default.network"
-
-    # install net-lib.sh regardless of its parent module's status
-    inst_simple "$moddir/../40network/net-lib.sh" /lib/net-lib.sh ||
-    dfatal 'Could not install net-lib.sh from the network module'
 
     # add a hook to generate networkd configuration from ip= arguments
     inst_hook cmdline 99 "$moddir/parse-ip-for-networkd.sh"

--- a/dracut/03flatcar-network/module-setup.sh
+++ b/dracut/03flatcar-network/module-setup.sh
@@ -15,6 +15,9 @@ install() {
         $systemdsystemunitdir/systemd-resolved.service \
         /etc/systemd/resolved.conf
 
+    inst_multiple \
+        "$systemdnetwork"/{20-calico-tunl0,50-veth,98-{gce-coreos-virtio,gce-virtio,virtio}}.link
+
     inst_simple "$moddir/network-cleanup.service" \
         "$systemdsystemunitdir/network-cleanup.service"
 
@@ -28,19 +31,19 @@ install() {
         "$systemdsystemunitdir/systemd-resolved.service.d/10-nodeps.conf"
 
     inst_simple "$moddir/yy-azure-sriov.network" \
-        "$systemdutildir/network/yy-azure-sriov.network"
+        "$systemdnetwork/yy-azure-sriov.network"
 
     inst_simple "$moddir/yy-digitalocean.network" \
-        "$systemdutildir/network/yy-digitalocean.network"
+        "$systemdnetwork/yy-digitalocean.network"
 
     inst_simple "$moddir/yy-netroot.network" \
-        "$systemdutildir/network/yy-netroot.network"
+        "$systemdnetwork/yy-netroot.network"
 
     inst_simple "$moddir/yy-pxe.network" \
-        "$systemdutildir/network/yy-pxe.network"
+        "$systemdnetwork/yy-pxe.network"
 
     inst_simple "$moddir/zz-default.network" \
-        "$systemdutildir/network/zz-default.network"
+        "$systemdnetwork/zz-default.network"
 
     # add a hook to generate networkd configuration from ip= arguments
     inst_hook cmdline 99 "$moddir/parse-ip-for-networkd.sh"

--- a/dracut/10diskless-generator/module-setup.sh
+++ b/dracut/10diskless-generator/module-setup.sh
@@ -8,7 +8,7 @@ depends() {
 }
 
 install() {
-    dracut_install mkfs.btrfs truncate
+    inst_multiple mkfs.btrfs truncate
     inst_simple "$moddir/diskless-btrfs" "$systemdutildir/diskless-btrfs"
     inst_simple "$moddir/diskless-generator" \
         "$systemdutildir/system-generators/diskless-generator"

--- a/dracut/10usr-fsck-generator/module-setup.sh
+++ b/dracut/10usr-fsck-generator/module-setup.sh
@@ -7,7 +7,7 @@ depends() {
 }
 
 install() {
-    dracut_install tr
+    inst_multiple tr
     inst_simple "$moddir/usr-fsck-generator" \
         "$systemdutildir/system-generators/usr-fsck-generator"
 }

--- a/dracut/10usr-generator/module-setup.sh
+++ b/dracut/10usr-generator/module-setup.sh
@@ -7,7 +7,7 @@ depends() {
 }
 
 install() {
-    dracut_install tr
+    inst_multiple tr
     inst_simple "$moddir/usr-generator" \
         "$systemdutildir/system-generators/usr-generator"
     inst_simple "$moddir/remount-sysroot.service" \

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -58,6 +58,8 @@ install() {
         clevis-luks-common-functions \
         clevis-luks-unlock \
         pwmake \
+        sort \
+        tail \
         tpm2_create
 
     # Required by s390x's z/VM installation.
@@ -93,6 +95,7 @@ install() {
     inst_simple "$moddir/ignition-generator" \
         "$systemdutildir/system-generators/ignition-generator"
 
+    local x
     for x in "complete" "subsequent" "diskful" "diskful-subsequent"; do
         inst_simple "$moddir/ignition-$x.target" \
             "$systemdsystemunitdir/ignition-$x.target"
@@ -129,58 +132,36 @@ install() {
     # Flatcar: add 66-azure-storage.rules and 90-cloud-storage.rules
     inst_rules 60-cdrom_id.rules 66-azure-storage.rules 90-cloud-storage.rules
 
-    # Flatcar: add symlinks for dependencies of Ignition, coreos-metadata (afterburn), and 
+    # Flatcar: add symlinks for dependencies of Ignition, coreos-metadata (afterburn), and
     # Clevis. This saves space in the initramfs image by replacing files with symlinks to
     # the previously mounted /sysusr/.
-    for executable in \
-        /usr/bin/clevis-decrypt-sss \
-        /usr/bin/clevis-decrypt-tang \
-        /usr/bin/clevis-decrypt-tpm2 \
-        /usr/bin/clevis-decrypt \
-        /usr/bin/clevis-encrypt-sss \
-        /usr/bin/clevis-encrypt-tang \
-        /usr/bin/clevis-encrypt-tpm2 \
-        /usr/bin/clevis-luks-bind \
-        /usr/bin/clevis-luks-common-functions \
-        /usr/bin/clevis-luks-list \
-        /usr/bin/clevis-luks-unlock \
-        /usr/bin/clevis \
-        /usr/bin/coreos-metadata \
-        /usr/bin/curl \
-        /usr/bin/ignition \
-        /usr/bin/jose \
-        /usr/bin/luksmeta \
-        /usr/bin/mktemp \
-        /usr/bin/pwmake \
-        /usr/bin/sort \
-        /usr/bin/tail \
-        /usr/bin/tpm2_createprimary \
-        /usr/bin/tpm2_create \
-        /usr/bin/tpm2_flushcontext \
-        /usr/bin/tpm2_load \
-        /usr/bin/tpm2_pcrlist \
-        /usr/bin/tpm2_pcrread \
-        /usr/bin/tpm2_unseal \
-        /usr/lib/systemd-reply-password \
-        /usr/local/libexec/clevis-luks-askpass \
-        /usr/libexec/clevis-luks-generic-unlocker \
-        /usr/sbin/setfiles \
-    ; do
-        directory="$(dirname "$executable")"
-        filename="$(basename "$executable")"
+    local executable
+    for executable in "${dracutsysrootdir}"{\
+/usr/bin/clevis*,\
+/usr/bin/coreos-metadata,\
+/usr/bin/curl,\
+/usr/bin/ignition,\
+/usr/bin/jose,\
+/usr/bin/luksmeta,\
+/usr/bin/tpm2,\
+/usr/lib/systemd/systemd-reply-password,\
+/usr/libexec/clevis*\
+}; do
+        if [[ ! -f ${executable} ]]; then
+            dfatal "Cannot create wrapper for ${executable} because it is not found"
+            exit 1
+        elif [[ ! -x ${executable} ]]; then
+            continue
+        fi
 
-        wrapper_name="${filename}-wrapper"
-        cat <<EOF > /tmp/${filename}-wrapper
+        local wrapper="${DRACUT_TMPDIR}/${executable##*/}-wrapper"
+        cat <<EOF > "${wrapper}"
 #!/bin/sh
-
-LD_LIBRARY_PATH=/sysusr/usr/lib64 exec "/sysusr${executable}" "\$@"
+LD_LIBRARY_PATH=/sysusr/usr/lib64 exec "/sysusr${executable#"$dracutsysrootdir"}" "\$@"
 EOF
-        chmod +x /tmp/${filename}-wrapper
-
-        inst_script "/tmp/${filename}-wrapper" \
-            "/usr/bin/$filename"
-            
-        rm /tmp/${filename}-wrapper
+        chmod +x "${wrapper}"
+        inst_script "${wrapper}" "${executable#"$dracutsysrootdir"}"
+        rm "${wrapper}"
     done
 
 }

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -164,6 +164,9 @@ EOF
         rm "${wrapper}"
     done
 
+    # Ensure /sysusr/usr is mounted before decrypting root.
+    inst_simple "$moddir/sysusr-usr-revdeps.conf" \
+        "$systemdsystemunitdir/systemd-cryptsetup@rootencrypted.service.d/sysusr-usr.conf"
 }
 
 # See: https://github.com/coreos/ignition/commit/d304850c3d3696822bc05e0833ee4b27df9d7a38

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -13,7 +13,7 @@ install_ignition_unit() {
     local instantiated="${1:-$unit}"; shift
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
     mkdir -p "$initdir/$systemdsystemunitdir/$target.requires"
-    ln_r "../$unit" "$systemdsystemunitdir/$target.requires/$instantiated"
+    ln -sfn "../$unit" "$initdir/$systemdsystemunitdir/$target.requires/$instantiated"
 }
 
 install() {

--- a/dracut/30ignition/sysusr-usr-revdeps.conf
+++ b/dracut/30ignition/sysusr-usr-revdeps.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=sysusr-usr.mount
+After=sysusr-usr.mount

--- a/dracut/99flatcar-debloat/module-setup.sh
+++ b/dracut/99flatcar-debloat/module-setup.sh
@@ -1,0 +1,21 @@
+config() {
+    # gcrypt: Only needed for systemd-journal's FSS feature.
+    # lz4: Flatcar has never needed this for the journal or coredumps.
+    omit_dlopen_features+=" libsystemd-shared-*.so:gcrypt,lz4 "
+}
+
+# shellcheck disable=SC2064
+trap "$(shopt -p extglob)" RETURN
+shopt -q -s extglob
+
+install() {
+    # shellcheck disable=SC2064
+    trap "$(shopt -p extglob)" RETURN
+    shopt -q -s extglob
+
+    # Remove the NSS modules we don't need.
+    rm "${initdir}"/usr/lib*/libnss_!(dns|files|myhostname|resolve|systemd).so*
+
+    # We maybe should include this, but more work is needed for compliance.
+    rm "${initdir}"/usr/lib*/ossl-modules/fips.so
+}

--- a/dracut/99setup-root/module-setup.sh
+++ b/dracut/99setup-root/module-setup.sh
@@ -7,7 +7,7 @@ depends() {
 }
 
 install() {
-    dracut_install grep ldconfig mountpoint systemd-tmpfiles flatcar-tmpfiles realpath
+    inst_multiple grep ldconfig mountpoint systemd-tmpfiles flatcar-tmpfiles realpath
 
     inst_script "${moddir}/initrd-setup-root" \
 	        "/sbin/initrd-setup-root"

--- a/dracut/99setup-root/module-setup.sh
+++ b/dracut/99setup-root/module-setup.sh
@@ -7,7 +7,7 @@ depends() {
 }
 
 install() {
-    inst_multiple grep ldconfig mountpoint systemd-tmpfiles flatcar-tmpfiles realpath
+    inst_multiple chroot grep ldconfig mountpoint systemd-tmpfiles flatcar-tmpfiles realpath
 
     inst_script "${moddir}/initrd-setup-root" \
 	        "/sbin/initrd-setup-root"

--- a/dracut/99shadow/module-setup.sh
+++ b/dracut/99shadow/module-setup.sh
@@ -5,15 +5,8 @@
 install() {
     # Simply pull in all the shadow db files so things like systemd-tmpfiles
     # will always be able to find users referenced by the baselayout files.
-    cp -af "/usr/share/baselayout/passwd" \
-        "${initdir}/etc/passwd"
-
-    cp -af "/usr/share/baselayout/shadow" \
-        "${initdir}/etc/shadow"
-
-    cp -af "/usr/share/baselayout/group" \
-        "${initdir}/etc/group"
-
-    cp -af "/usr/share/baselayout/gshadow" \
-        "${initdir}/etc/gshadow"
+    inst_simple /usr/share/baselayout/passwd  /etc/passwd
+    inst_simple /usr/share/baselayout/shadow  /etc/shadow
+    inst_simple /usr/share/baselayout/group   /etc/group
+    inst_simple /usr/share/baselayout/gshadow /etc/gshadow
 }

--- a/update-bootengine
+++ b/update-bootengine
@@ -6,23 +6,13 @@
 
 set -e
 
-USAGE="Usage: $0 [-k 4.6.0] [-m] [-c /build/amd64-usr] [-o bootengine.cpio]
+USAGE="Usage: $0 [-k 4.6.0] [-r /build/amd64-usr] [-o bootengine.cpio]
 Options:
     -k VERSION  Kernel version of modules to include
-    -m          Setup mounts for /dev /proc /sys and /run
-    -c CHROOT   Chroot into the given directory
+    -r SYSROOT  Build the initrd using the given directory
     -o OUT.cpio Alternate path to write the initrd
 
 This tool uses dracut to update /usr/share/bootengine/bootengine.cpio
-
-Since dracut assumes it is always run on the target system we need to support
-wrapping it in a way that fools it into using the files from the target image.
-This is all kinds of terrible and only works because the target arch is the
-same as the host arch.
-
-After many terrible experiences from this procedure this script will create a
-new filesystem namespace when operating inside the chroot, that way anything
-bad that happens will be less likely to hurt the host system. But no promises!
 "
 
 DRACUT_ARGS=(
@@ -35,29 +25,22 @@ DRACUT_ARGS=(
     --kernel-cmdline "SYSTEMD_SULOGIN_FORCE=1"
     )
 
-SETUP_MOUNTS=
-USE_CHROOT=
-CPIO_PATH="/usr/share/bootengine/bootengine.cpio"
+USE_SYSROOT=
+CPIO_PATH=
 KERNEL=
-while getopts "hmc:k:o:" OPTION
+while getopts "hk:o:r:" OPTION
 do
     case $OPTION in
-        c) USE_CHROOT="$OPTARG";;
         k) KERNEL="$OPTARG";;
-        m) SETUP_MOUNTS=1;;
         o) CPIO_PATH="$OPTARG";;
+        r) USE_SYSROOT="$OPTARG";;
         h) echo "$USAGE"; exit;;
         *) exit 1;;
     esac
 done
 
-if [[ -n "$USE_CHROOT" && ! -d "$USE_CHROOT" ]]; then
-    echo "$0: chroot $USE_CHROOT does not exist!" >&2
-    exit 1
-fi
-
-if [[ -z "$USE_CHROOT" && "$SETUP_MOUNTS" -eq 1 ]]; then
-    echo "$0: -c chrootpath option is required with the -m option" >&2
+if [[ -n "$USE_SYSROOT" && ! -d "$USE_SYSROOT" ]]; then
+    echo "$0: sysroot directory $USE_SYSROOT does not exist!" >&2
     exit 1
 fi
 
@@ -66,38 +49,17 @@ if [[ $(id -u) -ne 0 ]]; then
     exit 1
 fi
 
-# Alternative to mount --make-rprivate /
-# Doing it the ugly way is required because if this is run inside a chroot
-# such as the CoreOS SDK / is unlikely to be a mount point.
-mount_private() {
-    awk '$7 ~ /^shared:/{print $5}' /proc/self/mountinfo \
-        | xargs -r -n1 mount --make-private
-}
-
-if [[ "$SETUP_MOUNTS" -eq 1 ]]; then
-    # To ensure we don't break the rest of the system re-run ourselves in
-    # a new namespace, that way no one else sees our mounts.
-    if cmp -s /proc/self/mountinfo /proc/${PPID}/mountinfo; then
-        echo "Creating new filesystem namespace"
-        exec unshare --mount -- "$0" "$@"
-        exit 1
-    fi
-
-    if cmp -s /proc/self/mountinfo /proc/${PPID}/mountinfo; then
-        echo "Creating a new filesystem namespace seems to have failed!" >&2
-        exit 1
-    fi
-
-    echo "Mounting virtual filesystems"
-    mount_private
-    mount -n -t proc proc "${USE_CHROOT}/proc"
-    mount -n --bind /dev "${USE_CHROOT}/dev"
-    mount -n --bind /sys "${USE_CHROOT}/sys"
-    mount -n --bind /run "${USE_CHROOT}/run"
+if [[ -n $USE_SYSROOT ]]; then
+    DRACUT_ARGS+=( --sysroot "${USE_SYSROOT}" )
 fi
 
+: "${CPIO_PATH:=${USE_SYSROOT}/usr/share/bootengine/bootengine.cpio}"
+
 if [[ -n "$KERNEL" ]]; then
-    DRACUT_ARGS+=( "--kver" "$KERNEL" )
+    DRACUT_ARGS+=(
+        --kver "${KERNEL}"
+        --kmoddir "${USE_SYSROOT}/lib/modules/${KERNEL}"
+    )
 else
     DRACUT_ARGS+=( "--no-kernel" )
 fi
@@ -107,15 +69,6 @@ fi
 DRACUT_NO_XATTR=1
 export DRACUT_NO_XATTR
 
-mkdir -p "${USE_CHROOT}$(dirname "$CPIO_PATH")"
-if [[ -n "$USE_CHROOT" ]]; then
-    # ROOT interferes with some utilities after chroot (gcc-config).
-    unset ROOT
-    echo "Running dracut in $USE_CHROOT"
-    LC_ALL=C chroot "$USE_CHROOT" ldconfig -X
-    LC_ALL=C chroot "$USE_CHROOT" dracut "${DRACUT_ARGS[@]}" "$CPIO_PATH"
-else
-    echo "Running dracut in root"
-    LC_ALL=C dracut "${DRACUT_ARGS[@]}" "$CPIO_PATH"
-fi
-chmod 644 "${USE_CHROOT}${CPIO_PATH}"
+mkdir -p "${CPIO_PATH%/*}"
+LC_ALL=C DRACUT_INSTALL=/usr/lib/dracut/dracut-install dracut "${DRACUT_ARGS[@]}" "$CPIO_PATH"
+chmod 644 "${CPIO_PATH}"

--- a/update-bootengine
+++ b/update-bootengine
@@ -29,12 +29,8 @@ DRACUT_ARGS=(
     --force
     --no-hostonly
     --no-compress
-    --omit lvm
-    --omit multipath
-    --omit network
-    --omit zfs
-    --add iscsi
-    --add i18n
+    --omit "fido2 lvm multipath network pkcs11 tpm2-tss zfs"
+    --add "i18n iscsi"
     --add-drivers "loop brd drbd nbd rbd mmc_block xen-blkfront zram libarc4 lru_cache zsmalloc"
     --kernel-cmdline "SYSTEMD_SULOGIN_FORCE=1"
     )

--- a/update-bootengine
+++ b/update-bootengine
@@ -36,6 +36,7 @@ DRACUT_ARGS=(
     --add iscsi
     --add i18n
     --add-drivers "loop brd drbd nbd rbd mmc_block xen-blkfront zram libarc4 lru_cache zsmalloc"
+    --kernel-cmdline "SYSTEMD_SULOGIN_FORCE=1"
     )
 
 SETUP_MOUNTS=


### PR DESCRIPTION
# Misc changes needed to use new Dracut with sysroot feature

This must be reviewed in tandem with flatcar/scripts#2837.

Flatcar has lagged behind on Dracut 053 for quite a while. The latest version is currently 106, although it did jump from 060 to 100 when it changed hands.

It's hard to summarise the changes here, so please see the commit messages. The main change is that we now run Dracut with its `--sysroot` argument, removing the need to chroot and jump through hoops to avoid the Portage sandbox in the coreos-kernel ebuild.

Before you ask, the extglob stuff _is_ needed twice, once when the script is parsed, and once when the `install()` function is executed. Bash is weird.

## How to use

This is only usable with my chewi/dracut branch in flatcar/scripts. You will need the latest SDK due to changes in my earlier PR. You should be able to update dracut in the SDK, plus dracut and bootengine in the board root, before building coreos-kernel.

## Testing done

I have done a lot of manual testing and [CI testing](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/5825/cldsv/), as well as a close inspection of the initrd changes, in tandem with my chewi/dracut branch in flatcar/scripts.

- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.