### PR TITLE
fix bugs in sysusr-usr.mount and initrd-setup-root-after-ignition.service

### DIFF
--- a/dracut/10usr-generator/usr-generator
+++ b/dracut/10usr-generator/usr-generator
@@ -38,7 +38,7 @@ usrflags=$(cmdline_arg usrflags ro)
 if [[ "$(echo ",${usrflags}," | grep -v -F ',ro,')" != "" ]]; then
   true # Don't set "norecovery" when mounting rw
 else
-  usrflags="${usrflags},norecovery"
+  usrflags="${usrflags},rescue=nologreplay"
 fi
 
 case "${usr}" in
@@ -74,7 +74,7 @@ if [[ "${usr}" != /* ]]; then
     # Don't set "norecovery" when mounting rw
     exit 0
   fi
-  mount_usrflags="${mount_usrflags},norecovery"
+  mount_usrflags="${mount_usrflags},rescue=nologreplay"
   # sysroot-usr.mount is a bind mount from /sysusr/usr
   mkdir -p "${UNIT_DIR}/sysusr-usr.mount.d"
   cat >"${UNIT_DIR}/sysusr-usr.mount.d/10-norecovery.conf" <<EOF

--- a/dracut/99setup-root/initrd-setup-root-after-ignition
+++ b/dracut/99setup-root/initrd-setup-root-after-ignition
@@ -33,7 +33,7 @@ function download_and_verify() {
   local tempdir="/sysroot/ue-rs/"
   rm -rf "${tempdir}"
   mkdir -p "${tempdir}"
-  usrbin download_sysext -p /sysroot/usr/share/update_engine/update-payload-key.pub.pem -o "${tempdir}" -u "${URL}" || { rm -f "${tempdir}" ; echo "Failing boot" >&2 ; exit 1; }
+  usrbin download_sysext -p /sysroot/usr/share/update_engine/update-payload-key.pub.pem -o "${tempdir}" -u "${URL}" || { rm -rf "${tempdir}" ; echo "Failing boot" >&2 ; exit 1; }
   mv "${tempdir}/${extracted_name}" "/sysroot/${final_name}"
   rm -rf "${tempdir}"
   true # Don't leak previous exit code as return code


### PR DESCRIPTION
# fix bugs in sysusr-usr.mount and initrd-setup-root-after-ignition.service

## initrd-setup-root-after-ignition

Missing -r flag to rm results in failure to remove a directory when downloading sysexts fails. Other removes of `$tempdir` in the same block pass `-rf`. This occurred in a user reported issue where the log contains:

```
rm: cannot remove '/sysroot/ue-rs/': Is a directory
```

Can be reprod by downloading large sysexts (eg. ollama) on a non-vm disk image, which have a smaller starting root partition size.

## sysusr-usr.mount
Mounting /sysusr/usr in the initrd results in a warning:
```
# systemctl start sysusr-usr.mount
[  109.020881] systemd[1]: Starting systemd-fsck-usr.service...
[  109.024104] systemd[1]: Starting systemd-tmpfiles-setup-dev-early.service - Create Static Device Nodes in /dev gracefully...
[  109.048155] systemd[1]: Finished systemd-fsck-usr.service.
[  109.055150] systemd[1]: Finished systemd-tmpfiles-setup-dev-early.service - Create Static Device Nodes in /dev gracefully.
[  109.057082] systemd[1]: Reached target local-fs-pre.target - Preparation for Local File Systems.
[  109.057648] systemd[1]: Mounting sysusr-usr.mount - /sysusr/usr...
[  109.499758] BTRFS info: 'norecovery' is for compatibility only, recommended to use 'rescue=nologreplay'
[  109.504806] BTRFS: device fsid 9d124217-7448-4fc6-a329-8a233bb5a0ac devid 1 transid 38 /dev/mapper/usr (253:0) scanned by mount (1274)
[  109.511471] BTRFS info (device dm-0): first mount of filesystem 9d124217-7448-4fc6-a329-8a233bb5a0ac
[  109.515873] BTRFS info (device dm-0): using crc32c (crc32c-intel) checksum algorithm
[  109.519814] BTRFS info (device dm-0): using free-space-tree
[  109.122199] systemd[1]: Mounted sysusr-usr.mount - /sysusr/usr.
```
This was fixed elsewhere but missed here.

## Testing done

TODO

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
