### PR TITLE
dracut: Reduce size with wrappers

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -144,6 +144,8 @@ install() {
 /usr/bin/jose,\
 /usr/bin/luksmeta,\
 /usr/bin/tpm2,\
+/usr/bin/xfs_db,\
+/usr/bin/xfs_repair,\
 /usr/lib/systemd/systemd-reply-password,\
 /usr/libexec/clevis*\
 }; do


### PR DESCRIPTION
The xfs repair binaries are large and the user might need them manually
for the rootfs but at that point we can load them from /usr, too,
through a wrapper script. They are not called automatically (fsck.xfs
does not exist because the journal is enough for regular recovery).

## How to use


## Testing done

Ran the wrappers and checked that fsck is not done automatically for xfs.