### PR TITLE
afterburn: set hostname for Scaleway OEM

### DIFF
--- a/dracut/30ignition/flatcar-metadata-hostname.service
+++ b/dracut/30ignition/flatcar-metadata-hostname.service
@@ -37,6 +37,7 @@ ConditionKernelCommandLine=|flatcar.oem.id=packet
 ConditionKernelCommandLine=|flatcar.oem.id=hetzner
 ConditionKernelCommandLine=|flatcar.oem.id=kubevirt
 ConditionKernelCommandLine=|flatcar.oem.id=proxmoxve
+ConditionKernelCommandLine=|flatcar.oem.id=scaleway
 
 OnFailure=emergency.target
 OnFailureJobMode=isolate


### PR DESCRIPTION
Everything is in the title. It has been raised on CNCF Slack that Scaleway hostname was not set. 

---

I've tested it and this has been tested by the user reporting the issue as well.

This has to be backported on some maintainance branches for bootengine. 