### PR TITLE
setup-root: added support for air-gapped updates

### DIFF
--- a/dracut/99setup-root/initrd-setup-root-after-ignition
+++ b/dracut/99setup-root/initrd-setup-root-after-ignition
@@ -1,6 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
+cmdline=( $(</proc/cmdline) )
+
+# Usage: cmdline_arg name default_value
+cmdline_arg() {
+    local name="$1" value="$2"
+    for arg in "${cmdline[@]}"; do
+        if [[ "${arg%%=*}" == "${name}" ]]; then
+            value="${arg#*=}"
+        fi
+    done
+    echo "${value}"
+}
+
 function usrbin() {
   local cmd="$1"
   shift
@@ -14,10 +27,10 @@ function download_and_verify() {
   local final_name="$1"
   local extracted_name="${final_name}"
   local name="${final_name/%.raw/.gz}"
-  local URL="https://update.release.flatcar-linux.net/${FLATCAR_BOARD}/${VERSION}/${name}"
+  local URL="${RELEASE_FILE_SERVER_URL}/${FLATCAR_BOARD}/${VERSION}/${name}"
   # Check for scripts:sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-au-key/files/developer-v1.pub.pem
   if [ "$(usrbin md5sum /sysroot/usr/share/update_engine/update-payload-key.pub.pem | cut -d " " -f 1)" = "7192addf4a7f890c0057d21653eff2ea" ]; then
-    URL="https://bincache.flatcar-linux.net/images/${FLATCAR_BOARD/-usr}/${VERSION}/flatcar_test_update-${name}"
+    URL="${DEV_FILE_SERVER_URL}/${FLATCAR_BOARD/-usr}/${VERSION}/flatcar_test_update-${name}"
     extracted_name="flatcar_test_update-${final_name}"
   fi
   local COUNT=""
@@ -46,6 +59,12 @@ function download_and_verify() {
 # would not be able to use the OEM partition as dynamically preferred storage.)
 VERSION=$(source /sysroot/usr/lib/os-release ; echo "${VERSION}")
 FLATCAR_BOARD=$(source /sysroot/usr/lib/os-release ; echo "${FLATCAR_BOARD}")
+
+BASE_RELEASE_FILE_SERVER_URL="https://update.release.flatcar-linux.net"
+RELEASE_FILE_SERVER_URL=$(cmdline_arg flatcar.release_file_server_url ${BASE_RELEASE_FILE_SERVER_URL})
+
+BASE_DEV_FILE_SERVER_URL="https://bincache.flatcar-linux.net/images"
+DEV_FILE_SERVER_URL=$(cmdline_arg flatcar.dev_file_server_url ${BASE_DEV_FILE_SERVER_URL})
 
 # Not all OEM partitions have an oem-release file but we require it now
 OEMID=$({ grep -m 1 -o "^ID=.*" /sysroot/oem/oem-release || true ; } | cut -d = -f 2)


### PR DESCRIPTION
It is currently impossible to use your own nebraska server in air-gapped environments to enable extensions without updating the OS version or to download missing extensions

## How to use
Enable necessary kernel parameters:
```
kernel_arguments:
  should_exist:
    - flatcar.release_file_server_url=https://update.release.flatcar-linux.net
    - flatcar.dev_file_server_url=https://bincache.flatcar-linux.net/images
```
## Testing done
A image was created on the flatcar-4426 branch and extensions were added to the local nginx file server.
With kernel_arguments, without Internet access:
```
# butane.yaml:
variant: flatcar
version: 1.0.0
storage:
  files:
    - path: /etc/flatcar/enabled-sysext.conf
      mode: 0644
      contents:
        inline: |
          python
          zfs
kernel_arguments:
  should_exist:
    # - flatcar.release_file_server_url=http://172.18.0.1:8080/flatcar
    - flatcar.dev_file_server_url=http://172.18.0.1:8080/flatcar


# logs:
Oct 09 14:47:09 localhost ignition[1142]: INFO     : Ignition finished successfully
Oct 09 14:47:09 localhost systemd[1]: Finished ignition-files.service - Ignition (files).
Oct 09 14:47:09 localhost systemd[1]: Starting ignition-quench.service - Ignition (record completion)...
Oct 09 14:47:09 localhost systemd[1]: Starting initrd-setup-root-after-ignition.service - Root filesystem completion...
Oct 09 14:47:09 localhost systemd[1]: ignition-quench.service: Deactivated successfully.
Oct 09 14:47:09 localhost systemd[1]: Finished ignition-quench.service - Ignition (record completion).
Oct 09 14:47:09 localhost initrd-setup-root-after-ignition[1188]: grep: /sysroot/usr/share/flatcar/enabled-sysext.conf: No such file or directory
Oct 09 14:47:09 localhost initrd-setup-root-after-ignition[1173]: Did not find /etc/flatcar/sysext/flatcar-python-4426.1.0+nightly-20251007-2100.raw
Oct 09 14:47:09 localhost systemd[1]: afterburn-network-kargs.service - Afterburn Initrd Setup Network Kernel Arguments was skipped because no trigger condition checks were met.
Oct 09 14:47:09 localhost initrd-setup-root-after-ignition[1203]: Args { output_dir: "/sysroot/ue-rs/", target_filename: None, input_xml: None, payload_url: Some("http://172.18.0.1:8080/flatcar/amd64/4426.1.0+nightly-20251007-2100/flatcar_test_update-flatcar-python.gz"), pubkey_file: "/sysroot/usr/share/update_engine/update-payload-key.pub.pem", image_match: [], take_first_match: false }
Oct 09 14:47:09 localhost initrd-setup-root-after-ignition[1203]: writing to /sysroot/ue-rs/.unverified/flatcar_test_update-flatcar-python.gz
Oct 09 14:47:10 localhost initrd-setup-root-after-ignition[1203]: Parsed and verified signature data from file "/sysroot/ue-rs/.unverified/flatcar_test_update-flatcar-python.gz"
Oct 09 14:47:10 localhost initrd-setup-root-after-ignition[1173]: Did not find /etc/flatcar/sysext/flatcar-zfs-4426.1.0+nightly-20251007-2100.raw
Oct 09 14:47:10 localhost systemd[1]: afterburn-network-kargs.service - Afterburn Initrd Setup Network Kernel Arguments was skipped because no trigger condition checks were met.
Oct 09 14:47:10 localhost initrd-setup-root-after-ignition[1220]: Args { output_dir: "/sysroot/ue-rs/", target_filename: None, input_xml: None, payload_url: Some("http://172.18.0.1:8080/flatcar/amd64/4426.1.0+nightly-20251007-2100/flatcar_test_update-flatcar-zfs.gz"), pubkey_file: "/sysroot/usr/share/update_engine/update-payload-key.pub.pem", image_match: [], take_first_match: false }
Oct 09 14:47:10 localhost initrd-setup-root-after-ignition[1220]: writing to /sysroot/ue-rs/.unverified/flatcar_test_update-flatcar-zfs.gz
Oct 09 14:47:10 localhost initrd-setup-root-after-ignition[1220]: Parsed and verified signature data from file "/sysroot/ue-rs/.unverified/flatcar_test_update-flatcar-zfs.gz"
Oct 09 14:47:10 localhost systemd[1]: Finished initrd-setup-root-after-ignition.service - Root filesystem completion.
Oct 09 14:47:10 localhost systemd[1]: Reached target ignition-complete.target - Ignition Complete.


# Checks:
test-vm ~ # cat /proc/cmdline       
rootflags=rw mount.usrflags=ro BOOT_IMAGE=/flatcar/vmlinuz-a mount.usr=/dev/mapper/usr verity.usr=PARTUUID=7130c94a-213a-4e5a-8e26-6cce9662f132 rootflags=rw mount.usrflags=ro consoleblank=0 root=LABEL=ROOT console=ttyS0,115200n8 console=tty0 flatcar.first_boot=detected flatcar.oem.id=qemu flatcar.dev_file_server_url=http://172.18.0.1:8080/flatcar verity.usrhash=e96b276db8e4d370fb6f1915cdfd8cfb4100bcefa977451d59b34e84f4e65d74

test-vm ~ # ls -lah /etc/flatcar/sysext/        
total 25M
drwxr-xr-x. 2 root root 4.0K Oct  9 14:47 .
drwxr-xr-x. 1 root root 4.0K Oct  9 14:47 ..
-rw-r--r--. 1 root root  21M Oct  9 14:47 flatcar-python-4426.1.0+nightly-20251007-2100.raw
-rw-r--r--. 1 root root 4.0M Oct  9 14:47 flatcar-zfs-4426.1.0+nightly-20251007-2100.raw
```

Without kernel_arguments
```
# butane.yaml:
variant: flatcar
version: 1.0.0
storage:
  files:
    - path: /etc/flatcar/enabled-sysext.conf
      mode: 0644
      contents:
        inline: |
          python
          # zfs

core@localhost ~ $ cat /etc/flatcar/enabled-sysext.conf 
python
# zfs
core@localhost ~ $ ls -lah /etc/flatcar/sysext/
total 21M
drwxr-xr-x. 2 root root 4.0K Oct  9 15:44 .
drwxr-xr-x. 1 root root 4.0K Oct  9 15:44 ..
-rw-r--r--. 1 root root  21M Oct  9 15:44 flatcar-python-4426.1.0+nightly-20251007-2100.raw
core@localhost ~ $ cat /proc/cmdline 
rootflags=rw mount.usrflags=ro BOOT_IMAGE=/flatcar/vmlinuz-a mount.usr=/dev/mapper/usr verity.usr=PARTUUID=7130c94a-213a-4e5a-8e26-6cce9662f132 rootflags=rw mount.usrflags=ro consoleblank=0 root=LABEL=ROOT console=ttyS0,115200n8 console=tty0 flatcar.first_boot=detected flatcar.oem.id=qemu flatcar.autologin verity.usrhash=e96b276db8e4d370fb6f1915cdfd8cfb4100bcefa977451d59b34e84f4e65d74


Oct 09 15:44:12 localhost ignition[1121]: INFO     : Ignition finished successfully
Oct 09 15:44:12 localhost systemd[1]: Finished ignition-files.service - Ignition (files).
Oct 09 15:44:12 localhost systemd[1]: Starting ignition-quench.service - Ignition (record completion)...
Oct 09 15:44:12 localhost systemd[1]: Starting initrd-setup-root-after-ignition.service - Root filesystem completion...
Oct 09 15:44:12 localhost systemd[1]: ignition-quench.service: Deactivated successfully.
Oct 09 15:44:12 localhost systemd[1]: Finished ignition-quench.service - Ignition (record completion).
Oct 09 15:44:12 localhost initrd-setup-root-after-ignition[1151]: grep: /sysroot/usr/share/flatcar/enabled-sysext.conf: No such file or directory
Oct 09 15:44:12 localhost initrd-setup-root-after-ignition[1136]: Did not find /etc/flatcar/sysext/flatcar-python-4426.1.0+nightly-20251007-2100.raw
Oct 09 15:44:12 localhost systemd[1]: afterburn-network-kargs.service - Afterburn Initrd Setup Network Kernel Arguments was skipped because no trigger condition checks were met.
Oct 09 15:44:12 localhost systemd-networkd[911]: eth0: Gained IPv6LL
Oct 09 15:44:13 localhost initrd-setup-root-after-ignition[1166]: Args { output_dir: "/sysroot/ue-rs/", target_filename: None, input_xml: None, payload_url: Some("https://bincache.flatcar-linux.net/images/amd64/4426.1.0+nightly-20251007-2100/flatcar_test_update-flatcar-python.gz"), pubkey_file: "/sysroot/usr/share/update_engine/update-payload-key.pub.pem", image_match: [], take_first_match: false }
Oct 09 15:44:13 localhost initrd-setup-root-after-ignition[1166]: writing to /sysroot/ue-rs/.unverified/flatcar_test_update-flatcar-python.gz
Oct 09 15:44:26 localhost initrd-setup-root-after-ignition[1166]: Parsed and verified signature data from file "/sysroot/ue-rs/.unverified/flatcar_test_update-flatcar-python.gz"
Oct 09 15:44:26 localhost systemd[1]: Finished initrd-setup-root-after-ignition.service - Root filesystem completion.
Oct 09 15:44:26 localhost systemd[1]: Reached target ignition-complete.target - Ignition Complete.
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
