### PR TITLE
minimal-init: Use kmod's modprobe also for simple module loading

### DIFF
--- a/minimal-init
+++ b/minimal-init
@@ -50,7 +50,7 @@ mdev -s
 # because busybox doesn't properly support the globs in modules.alias
 find /sys/ -name modalias -print0 | xargs -0 sort -u | tr '\n' '\0' | xargs -0 /sbin/modprobe -abq || true
 # Required to access disks, but not autoloaded:
-modprobe sd_mod
+/sbin/modprobe sd_mod
 
 debug_sh 2/4: before verity
 
@@ -163,12 +163,12 @@ debug_sh 3/4: before /sysusr mount
 
 echo "Mounting /usr from ${usr}" >&2
 # mount -t auto only works if btrfs is already loaded
-modprobe btrfs
+/sbin/modprobe btrfs
 mkdir -p /sysusr/usr
 mount -t "${usrfstype}" -o "${usrflags}" "${usr}" /sysusr/usr
 
 # Busybox doesn't load this for us
-modprobe loop
+/sbin/modprobe loop
 LOOP=$(losetup -f)
 losetup -r "${LOOP}" /sysusr/usr/lib/flatcar/bootengine.img
 mkdir /underlay /work


### PR DESCRIPTION
We already use kmod's modprobe for loading drivers from alias entries but still used busybox's modprobe for the three explicit calls. This caused a "Invalid ELF header magic: != ELF" warning being printed while it tries to load the compressed module before uncompressing. While harmless this does not look good and is confusing. Always use kmod's modprobe for module loading. Whether busybox prefers builtins or not is a configuration option and we shouldn't assume it always is configured in a particular way, so an explicit call is best.

Fixes https://github.com/flatcar/Flatcar/issues/1934

## How to use

Backport to Alpha

## Testing done

The messages are gone with the image built from the CI.