### PR TITLE
afterburn: sync network kargs with supported provider

### DIFF
--- a/dracut/50flatcar-network/afterburn-network-kargs.service
+++ b/dracut/50flatcar-network/afterburn-network-kargs.service
@@ -10,6 +10,11 @@ PartOf=systemd-networkd.service
 # For extra safety
 ConditionKernelCommandLine=|coreos.oem.id=vmware
 ConditionKernelCommandLine=|flatcar.oem.id=vmware
+ConditionKernelCommandLine=|coreos.oem.id=proxmoxve
+ConditionKernelCommandLine=|flatcar.oem.id=proxmoxve
+ConditionKernelCommandLine=|coreos.oem.id=kubevirt
+ConditionKernelCommandLine=|flatcar.oem.id=kubevirt
+
 OnFailure=emergency.target
 OnFailureJobMode=replace-irreversibly
 

--- a/dracut/50flatcar-network/parse-ip-for-networkd.sh
+++ b/dracut/50flatcar-network/parse-ip-for-networkd.sh
@@ -68,6 +68,8 @@ function mask2cidr() {
     echo $bits
 }
 
+nameserver=$(getarg nameserver=)
+
 # Check ip= lines
 # XXX Would be nice if we could errorcheck ip addresses here as well
 for p in $(getargs ip=); do
@@ -128,6 +130,7 @@ for p in $(getargs ip=); do
     [ -n "$gw" ] && echo "Gateway=$gw" >> $_net_file
     [ -n "$dns1" ] && echo "DNS=$dns1" >> $_net_file
     [ -n "$dns2" ] && echo "DNS=$dns2" >> $_net_file
+    [ -n "$nameserver" ] && echo "DNS=$nameserver" >> $_net_file
     echo '[Address]' >> $_net_file
     [ -n "$ip" ] && echo "Address=$ip/${cidr:-24}" >> $_net_file
     [ -n "$srv" ] && echo "Peer=$srv" >> $_net_file

--- a/dracut/50flatcar-network/parse-ip-for-networkd.sh
+++ b/dracut/50flatcar-network/parse-ip-for-networkd.sh
@@ -121,6 +121,7 @@ for p in $(getargs ip=); do
     mkdir -p /etc/systemd/network
     echo '[Match]' > $_net_file
     _dev=${dev:-"*"}; echo "Name=$_dev" >> $_net_file
+    echo "Type=!loopback" >> $_net_file
     echo '[Link]' >> $_net_file
     [ -n "$macaddr" ] && echo "MACAddress=$macaddr" >> $_net_file
     [ -n "$mtu" ] && echo "MTUBytes=$mtu" >> $_net_file


### PR DESCRIPTION
There is now a support for ProxmoxVE and Kubevirt: https://github.com/coreos/afterburn/blob/8f6d5877c96b4d974f18a4782e6e275efdbd94d6/src/initrd/mod.rs#L20-L24
