### PR TITLE
Allow use of legacy OEM path while migrating modules to the new path

### DIFF
--- a/dracut/53ignition/ignition-setup.sh
+++ b/dracut/53ignition/ignition-setup.sh
@@ -19,10 +19,7 @@ normal)
     ;;
 pxe)
     # OEM directory in the initramfs itself.
-    # Despite having the OEM partition being moved to
-    # /oem in general, we keep checking /usr/share/oem in initrds to avoid
-    # breaking compatibility.
-    src=/usr/share/oem
+    src=/oem
     # Workaround, "chmod" is not available
     cp -a /bin/cat /bin/is-live-image
     printf '#!/bin/sh\nexit 0\n' > /bin/is-live-image

--- a/dracut/99setup-root/initrd-setup-root
+++ b/dracut/99setup-root/initrd-setup-root
@@ -175,9 +175,7 @@ SYSTEMD_IN_INITRD=0 systemd-confext --root=/sysroot status | grep flatcar-defaul
 # to be applied and we can later rely on the confext/sysext .services
 # for that while the above call is specific to Flatcar/Ignition.
 
-# PXE initrds may provide OEM. Despite OEM partition being moved to
-# /oem in general, we keep checking /usr/share/oem in initrds to avoid
-# breaking compatibility.
-if [ -d /usr/share/oem ] && mountpoint --quiet /sysroot/oem; then
-    cp -Ra /usr/share/oem/. /sysroot/oem
+# PXE initrds may provide OEM.
+if [ -d /oem ] && mountpoint --quiet /sysroot/oem; then
+    cp -Ra /oem/. /sysroot/oem
 fi

--- a/minimal-init
+++ b/minimal-init
@@ -192,8 +192,7 @@ mount -o move /sysusr/usr /realinit/sysusr/usr
 if [ "${usr}" = /usr.squashfs ]; then
   # Move either /oem (preferred) or /usr/share/oem (legacy) into the new root.
   mv /oem /realinit || mv /usr/share/oem /realinit || true
-  touch /realinit/usr.squashfs
-  mount -o bind /usr.squashfs /realinit/usr.squashfs
+  mv /usr.squashfs /realinit
 fi
 debug_sh 4/4: before switch_root to /realinit
 killall mdev || true

--- a/minimal-init
+++ b/minimal-init
@@ -190,9 +190,8 @@ mount -t overlay -o rw,lowerdir=/underlay,upperdir=/work/realinit,workdir=/work/
 mkdir -p /realinit/sysusr/usr
 mount -o move /sysusr/usr /realinit/sysusr/usr
 if [ "${usr}" = /usr.squashfs ]; then
-  mkdir -p /oem
-  mkdir -p /realinit/oem
-  mount -o bind /oem /realinit/oem
+  # Move either /oem (preferred) or /usr/share/oem (legacy) into the new root.
+  mv /oem /realinit || mv /usr/share/oem /realinit || true
   touch /realinit/usr.squashfs
   mount -o bind /usr.squashfs /realinit/usr.squashfs
 fi


### PR DESCRIPTION
# Allow legacy OEM path while migrating to new path

The new minimal-init passed the contents of `/oem` to the second stage, but not the legacy `/usr/share/oem` path that is still [documented](https://www.flatcar.org/docs/latest/installing/bare-metal/booting-with-pxe/#adding-a-custom-oem). This change moves either the former or the latter into the second stage. This is no longer done via a bind mount, as that adds unnecessary complexity.

At the same time, Dracut modules in the second stage can simply reference `/oem` rather than `/usr/share/oem` now that the first stage deals with the migration.

This addresses flatcar/Flatcar#2023.

## How to use

Try the [documented](https://www.flatcar.org/docs/latest/installing/bare-metal/booting-with-pxe/#adding-a-custom-oem) method. You can also try it with `/oem` instead of `/usr/share/oem`.

## Testing done

I've successfully done the above with both paths. I've also kicked off a [Jenkins run](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/7513/cldsv/), which passed aside from bpf.execsnoop.