### PR TITLE
Changes for systemd 259

### DIFF
--- a/dracut/99flatcar-debloat/module-setup.sh
+++ b/dracut/99flatcar-debloat/module-setup.sh
@@ -18,4 +18,9 @@ install() {
 
     # We maybe should include this, but more work is needed for compliance.
     rm "${initdir}"/usr/lib*/ossl-modules/fips.so
+
+    # drop it when updating to dracut 110
+    inst_libdir_file "libaudit.so*"
+    inst_libdir_file "libpam.so*"
+    inst_libdir_file "libseccomp.so*"
 }

--- a/dracut/99setup-root/initrd-setup-root
+++ b/dracut/99setup-root/initrd-setup-root
@@ -32,8 +32,8 @@ COREOS_BLANK_MACHINE_ID="42000000000000000000000000000042"
 MACHINE_ID_FILE="/sysroot/etc/machine-id"
 
 # Allow to rerun the script
-if SYSTEMD_IN_INITRD=0 systemd-confext --root=/sysroot status | grep flatcar-default; then
-  SYSTEMD_IN_INITRD=0 systemd-confext --root=/sysroot unmerge
+if systemd-confext --root=/sysroot status | grep flatcar-default; then
+  systemd-confext --root=/sysroot unmerge
 fi
 
 function selectiveosreset() {
@@ -165,10 +165,8 @@ mkdir -p /sysroot/var/lib/extensions.mutable/
 if [ ! -L /sysroot/var/lib/extensions.mutable/etc ] && [ ! -e /sysroot/var/lib/extensions.mutable/etc ]; then
   ln -s /etc /sysroot/var/lib/extensions.mutable/etc
 fi
-# Workaround until 259: Set SYSTEMD_IN_INITRD because even with --root=
-# this would otherwise look for initrd extension metadata.
-SYSTEMD_IN_INITRD=0 systemd-confext --root=/sysroot merge
-SYSTEMD_IN_INITRD=0 systemd-confext --root=/sysroot status | grep flatcar-default || { echo "error: flatcar-default confext not loaded" ; exit 1 ; }
+systemd-confext --root=/sysroot merge
+systemd-confext --root=/sysroot status | grep flatcar-default || { echo "error: flatcar-default confext not loaded" ; exit 1 ; }
 # Even when the planned sysext/confext .services units are there
 # the above call should stay because we first need confext for Ignition
 # to have default files but then we need to reload for any user confexts

--- a/dracut/99setup-root/initrd-setup-root-after-ignition
+++ b/dracut/99setup-root/initrd-setup-root-after-ignition
@@ -168,11 +168,11 @@ for NAME in $(grep -h -o '^[^#]*' /sysroot/etc/flatcar/enabled-sysext.conf /sysr
 done
 
 # Here we load a second time so that any user-supplied configuration extensions are present at boot
-SYSTEMD_IN_INITRD=0 systemd-confext --root=/sysroot refresh
+systemd-confext --root=/sysroot refresh
 # Then for the first time we can also apply system extensions so that the final system has them at boot
 # (done here until we have an upstream systemd unit doing it).
 if [ $(readlink -f /sysroot/etc/systemd/system/systemd-sysext.service 2>/dev/null) != "/dev/null" ]; then
-  if ! SYSTEMD_IN_INITRD=0 systemd-sysext --root=/sysroot merge ; then
+  if ! systemd-sysext --root=/sysroot merge ; then
     echo "ERROR: systemd-sysext failed to set up extensions in initrd, continuing boot" >&2
   fi
 fi

--- a/dracut/99switch-root/nocgroup.conf
+++ b/dracut/99switch-root/nocgroup.conf
@@ -1,7 +1,5 @@
 [Manager]
-DefaultCPUAccounting=no
 DefaultIOAccounting=no
 DefaultIPAccounting=no
-DefaultBlockIOAccounting=no
 DefaultMemoryAccounting=no
 DefaultTasksAccounting=no

--- a/update-bootengine
+++ b/update-bootengine
@@ -20,7 +20,7 @@ DRACUT_ARGS=(
     --force
     --no-hostonly
     --no-compress
-    --omit "fido2 lvm multipath network pkcs11 tpm2-tss zfs"
+    --omit "bluetooth fido2 lvm multipath network pkcs11 tpm2-tss zfs"
     --add "i18n iscsi"
     --add-drivers "loop brd drbd nbd rbd mmc_block xen-blkfront zram libarc4 lru_cache zsmalloc vboxguest"
     --kernel-cmdline "SYSTEMD_SULOGIN_FORCE=1"

--- a/update-bootengine
+++ b/update-bootengine
@@ -20,7 +20,7 @@ DRACUT_ARGS=(
     --force
     --no-hostonly
     --no-compress
-    --omit "bluetooth fido2 lvm multipath network pkcs11 tpm2-tss zfs"
+    --omit "bluetooth cifs fido2 lvm multipath network nfs nvmf pkcs11 tpm2-tss zfs"
     --add "i18n iscsi"
     --add-drivers "loop brd drbd nbd rbd mmc_block xen-blkfront zram libarc4 lru_cache zsmalloc vboxguest"
     --kernel-cmdline "SYSTEMD_SULOGIN_FORCE=1"


### PR DESCRIPTION
Dropped some now-unnecessary workarounds, add temporary hacks for adding more required dlopened libraries, dropped obsolete systemd manager options and disabled some dracut modules (they were disabled implicitly, but dracut complained about them).

Tested together with weekly package updates: https://github.com/flatcar/scripts/pull/3852