### PR TITLE
ignition: Improve OEM detection and fix VirtualBox

### DIFF
--- a/dracut/53ignition/flatcar-metadata-hostname.service
+++ b/dracut/53ignition/flatcar-metadata-hostname.service
@@ -30,9 +30,6 @@ ConditionKernelCommandLine=|coreos.oem.id=ibmcloud
 ConditionKernelCommandLine=|flatcar.oem.id=ibmcloud
 ConditionKernelCommandLine=|coreos.oem.id=vultr
 ConditionKernelCommandLine=|flatcar.oem.id=vultr
-# Addition:
-ConditionKernelCommandLine=|coreos.oem.id=packet
-ConditionKernelCommandLine=|flatcar.oem.id=packet
 
 ConditionKernelCommandLine=|flatcar.oem.id=hetzner
 ConditionKernelCommandLine=|flatcar.oem.id=kubevirt

--- a/dracut/53ignition/ignition-generator
+++ b/dracut/53ignition/ignition-generator
@@ -54,9 +54,6 @@ if $(cmdline_bool flatcar.first_boot 0) || $(cmdline_bool coreos.first_boot 0); 
     if [[ $(cmdline_arg flatcar.first_boot) = "detected" ]] || [[ $(cmdline_arg coreos.first_boot) = "detected" ]]; then
         add_requires ignition-quench.service initrd.target
     fi
-    if [[ $(cmdline_arg flatcar.oem.id) == "packet" ]] || [[ $(cmdline_arg coreos.oem.id) == "packet" ]]; then
-        add_requires flatcar-static-network.service initrd.target
-    fi
 
     # On EC2, shut down systemd-networkd if ignition fails so that the instance
     # fails EC2 instance checks.

--- a/dracut/53ignition/ignition-setup-pre.sh
+++ b/dracut/53ignition/ignition-setup-pre.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-cmdline=( $(</proc/cmdline) )
+read -r -a cmdline < /proc/cmdline
 cmdline_arg() {
     local name="$1" value="$2"
     for arg in "${cmdline[@]}"; do
@@ -15,28 +15,26 @@ cmdline_arg() {
 }
 
 oem_id=metal
-if [[ $(systemd-detect-virt || true) =~ ^(kvm|qemu)$ ]]; then
-    oem_id=qemu
+
+case $(systemd-detect-virt) in
+    kvm|qemu) oem_id=qemu ;;
+esac
+
+oem_cmdline=$(cmdline_arg flatcar.oem.id ${oem_id})
+if [[ ${oem_id} == "${oem_cmdline}" ]]; then
+    oem_cmdline=$(cmdline_arg coreos.oem.id ${oem_id})
 fi
 
-oem_cmdline="$(cmdline_arg flatcar.oem.id ${oem_id})"
-if [[ "${oem_id}" = "${oem_cmdline}" ]]; then
-    oem_cmdline="$(cmdline_arg coreos.oem.id ${oem_id})"
-fi
+case ${oem_cmdline} in
+    # Ignition changed the platform name to "aws"
+    ec2) oem_cmdline=aws ;;
+    # Ignition changed the platform name to "gcp"
+    gce) oem_cmdline=gcp ;;
+    # To maintain compatibility with eventual legacy 'flatcar.oem.id=pxe'
+    pxe) oem_cmdline=metal ;;
+esac
 
-# Ignition changed the platform name to "aws"
-if [ "${oem_cmdline}" = "ec2" ]; then
-  oem_cmdline="aws"
-fi
-
-# Ignition changed the platform name to "gcp"
-if [ "${oem_cmdline}" = "gce" ]; then
-  oem_cmdline="gcp"
-fi
-
-# To maintain compatibility with eventual legacy 'flatcar.oem.id=pxe'
-if [ "${oem_cmdline}" = "pxe" ]; then
-  oem_cmdline="metal"
-fi
-
-{ echo "OEM_ID=${oem_cmdline}" ; echo "PLATFORM_ID=${oem_cmdline}" ; } > /run/ignition.env
+cat > /run/ignition.env <<EOF
+OEM_ID=${oem_cmdline}
+PLATFORM_ID=${oem_cmdline}
+EOF

--- a/dracut/53ignition/ignition-setup-pre.sh
+++ b/dracut/53ignition/ignition-setup-pre.sh
@@ -18,6 +18,8 @@ oem_id=metal
 
 case $(systemd-detect-virt) in
     kvm|qemu) oem_id=qemu ;;
+    oracle) oem_id=virtualbox ;;
+    vmware) oem_id=vmware ;;
 esac
 
 oem_cmdline=$(cmdline_arg flatcar.oem.id ${oem_id})
@@ -30,8 +32,8 @@ case ${oem_cmdline} in
     ec2) oem_cmdline=aws ;;
     # Ignition changed the platform name to "gcp"
     gce) oem_cmdline=gcp ;;
-    # To maintain compatibility with eventual legacy 'flatcar.oem.id=pxe'
-    pxe) oem_cmdline=metal ;;
+    # Fall back to detection for cases unsupported by Ignition
+    cloudsigma|pxe|vagrant) oem_cmdline=${oem_id} ;;
 esac
 
 cat > /run/ignition.env <<EOF

--- a/update-bootengine
+++ b/update-bootengine
@@ -22,7 +22,7 @@ DRACUT_ARGS=(
     --no-compress
     --omit "fido2 lvm multipath network pkcs11 tpm2-tss zfs"
     --add "i18n iscsi"
-    --add-drivers "loop brd drbd nbd rbd mmc_block xen-blkfront zram libarc4 lru_cache zsmalloc"
+    --add-drivers "loop brd drbd nbd rbd mmc_block xen-blkfront zram libarc4 lru_cache zsmalloc vboxguest"
     --kernel-cmdline "SYSTEMD_SULOGIN_FORCE=1"
     )
 


### PR DESCRIPTION
# ignition: Improve OEM detection and fix VirtualBox

This falls back to detection for cases unsupported by Ignition, which saves us from having to patch these cases into Ignition like we have previously been doing.

It also means we can make a more useful guess than just "metal", which does nothing. For example, this allows you to pass config via qemu_fw when testing PXE with QEMU.

The vboxguest kernel module is added to support VirtualBox against new Ignition versions.

This also drops Equinix Metal (Packet) support.

## How to use

The easiest image to test this with is Vagrant... which isn't that easy. You'll need my wider OEM changes.

## Testing done

I've tried the above manually run [Jenkins](https://jenkins.flatcar.org/job/container/job/packages_all_arches/120/cldsv/), which passed where expected (eventually).