### PR TITLE
switch-root: Ensure sysctl is run again after switching root

### DIFF
--- a/dracut/99switch-root/module-setup.sh
+++ b/dracut/99switch-root/module-setup.sh
@@ -13,4 +13,9 @@ install() {
         "${systemdsystemunitdir}/initrd-parse-etc.service.d/override.conf"
     inst_simple "${moddir}/nocgroup.conf" \
         "/etc/systemd/system.conf.d/nocgroup.conf"
+
+    # Ensure sysctl is run again after switching root to pick up any sysctl
+    # files that are deliberately missing from the initrd.
+    inst_simple "${moddir}/rerun.conf" \
+        "${systemdsystemunitdir}/systemd-sysctl.service.d/rerun.conf"
 }

--- a/dracut/99switch-root/rerun.conf
+++ b/dracut/99switch-root/rerun.conf
@@ -1,0 +1,2 @@
+[Service]
+RemainAfterExit=no


### PR DESCRIPTION
Dracut normally copies all sysctl config to the initrd, but we may want to exclude platform-specific config because the initrd is shared between platforms. That config can be picked up from the OEM sysext after switching root.

I have tested this manually with GCE.