### PR TITLE
Adapt to dracut 110

### DIFF
--- a/dracut/50flatcar-network/parse-ip-for-networkd.service
+++ b/dracut/50flatcar-network/parse-ip-for-networkd.service
@@ -12,7 +12,7 @@ Conflicts=initrd-switch-root.target
 Type=oneshot
 RemainAfterExit=true
 Environment="APPLY=1"
-ExecStart=/lib/dracut/hooks/cmdline/99-parse-ip-for-networkd.sh
+ExecStart=/var/lib/dracut/hooks/cmdline/99-parse-ip-for-networkd.sh
 
 [Install]
 WantedBy=systemd-networkd.service

--- a/dracut/99flatcar-debloat/module-setup.sh
+++ b/dracut/99flatcar-debloat/module-setup.sh
@@ -18,9 +18,4 @@ install() {
 
     # We maybe should include this, but more work is needed for compliance.
     rm "${initdir}"/usr/lib*/ossl-modules/fips.so
-
-    # drop it when updating to dracut 110
-    inst_libdir_file "libaudit.so*"
-    inst_libdir_file "libpam.so*"
-    inst_libdir_file "libseccomp.so*"
 }

--- a/update-bootengine
+++ b/update-bootengine
@@ -21,7 +21,7 @@ DRACUT_ARGS=(
     --no-hostonly
     --no-compress
     --omit "bluetooth cifs fido2 lvm multipath network nfs nvmf pkcs11 tpm2-tss zfs"
-    --add "i18n iscsi"
+    --add "i18n iscsi systemd-coredump"
     --add-drivers "loop brd drbd nbd rbd mmc_block xen-blkfront zram libarc4 lru_cache zsmalloc vboxguest"
     --kernel-cmdline "SYSTEMD_SULOGIN_FORCE=1"
     )


### PR DESCRIPTION
- Dropped explicit installation of certain libraries that systemd is loading at runtime - dracut 110 now supports reading elf notes and installing libraries mentioned in those notes.
- Dracut 110 removed the compatibility link `/lib/dracut/hooks` -> `/var/lib/dracut/hooks`, so `parse-ip-for-networkd.service` started to fail, because it was still trying to invoke the hook script through the `/lib/dracut/hooks` path.
- Dracut 110 stopped installing systemd-coredump. Now, I'm not sure if we really needed it in the initrd - this change also brings coredumpctl into the initrd image.